### PR TITLE
Update typed-ast version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ rich==12.4.4
 six==1.16.0
 toml==0.10.1
 tqdm==4.64.0
-typed-ast==1.4.1
+typed-ast==1.5.4
 typing_extensions==4.2.0
 update-checker==0.18.0
 urllib3==1.26.9


### PR DESCRIPTION
The one used (1.4.1) is long outdated and not recommended by maintainers. The installation of an old version may fail for many.