### PR TITLE
stickied comments will no longer be used

### DIFF
--- a/reddit/askreddit.py
+++ b/reddit/askreddit.py
@@ -32,14 +32,15 @@ def get_askreddit_threads():
         content["comments"] = []
 
         for top_level_comment in submission.comments:
-            content["comments"].append(
+            if not top_level_comment.stickied:
+                content["comments"].append(
                 {
                     "comment_body": top_level_comment.body,
                     "comment_url": top_level_comment.permalink,
                     "comment_id": top_level_comment.id,
                 }
-            )
-
+                )
+   
     except AttributeError as e:
         pass
     print_substep("Received AskReddit threads Successfully.", style="bold green")


### PR DESCRIPTION
I made a Video but it was taken up entirely by a post looking like this: https://imgur.com/a/1fwT94c
This isn't a big deal because these serious tags are uncommon, but still a small annoyance. 
So I fixed it!
In threads that are marked 'serious' there is a automatic stickied mod post. ex. (shorturl.at/I1346). My changes will skip any automatically stickied comment, so they won't make it into the final Video.