### PR TITLE
stickied comments will no longer be used

### DIFF
--- a/reddit/subreddit.py
+++ b/reddit/subreddit.py
@@ -56,6 +56,7 @@ def get_subreddit_threads():
         content["comments"] = []
 
         for top_level_comment in submission.comments:
+           if not top_level_comment.stickied:
             content["comments"].append(
                 {
                     "comment_body": top_level_comment.body,


### PR DESCRIPTION
I made a video but it was taken up entirely by a post looking like this: https://imgur.com/a/1fwT94c
This isn't a big deal because these serious tags are uncommon, but still a small annoyance.
So I fixed it!
In threads that are marked 'serious', there is an automatic stickied mod post. ex. (shorturl.at/I1346). My changes will skip any automatically stickied comments, so they won't make it into the final Video.