### PR TITLE
tts will no longer read aloud link

### DIFF
--- a/main.py
+++ b/main.py
@@ -31,10 +31,10 @@ print_markdown(
 )
 
 """
--
+
 Load .env file if exists. If it doesnt exist, print a warning and launch the setup wizard.
 If there is a .env file, check if the required variables are set. If not, print a warning and launch the setup wizard.
--
+
 """
 
 client_id = os.getenv("REDDIT_CLIENT_ID")

--- a/main.py
+++ b/main.py
@@ -31,6 +31,9 @@ print_markdown(
 )
 
 """
+Load .env file if exists. If it doesnt exist, print a warning and launch the setup wizard.
+If there is a .env file, check if the required variables are set. If not, print a warning and launch the setup wizard.
+"""
 
 client_id = os.getenv("REDDIT_CLIENT_ID")
 client_secret = os.getenv("REDDIT_CLIENT_SECRET")
@@ -53,4 +56,43 @@ for val in REQUIRED_VALUES:
     if val not in os.environ or not os.getenv(val):
         console.log(f'[bold red]Missing Variable: "{val}"')
         configured = False
+        console.log(
+            "[red]Looks like you need to set your Reddit credentials in the .env file. Please follow the instructions in the README.md file to set them up."
+        )
+        time.sleep(0.5)
+        console.log(
+            "[red]We can also launch the easy setup wizard. type yes to launch it, or no to quit the program."
+        )
+        setup_ask = input("Launch setup wizard? > ")
+        if setup_ask == "yes":
+            console.log("[bold green]Here goes nothing! Launching setup wizard...")
+            time.sleep(0.5)
+            os.system("python3 setup.py")
 
+        elif setup_ask == "no":
+            console.print("[red]Exiting...")
+            time.sleep(0.5)
+            exit()
+        else:
+            console.print("[red]I don't understand that. Exiting...")
+            time.sleep(0.5)
+            exit()
+try:
+    float(os.getenv("OPACITY"))
+except:
+    console.log(
+        f"[red]Please ensure that OPACITY is set between 0 and 1 in your .env file"
+    )
+    configured = False
+    exit()
+console.log("[bold green]Enviroment Variables are set! Continuing...")
+
+if configured:
+    reddit_object = get_subreddit_threads()
+    length, number_of_comments = save_text_to_mp3(reddit_object)
+    download_screenshots_of_reddit_posts(
+        reddit_object, number_of_comments, os.getenv("THEME", "light")
+    )
+    download_background()
+    chop_background_video(length)
+    final_video = make_final_video(number_of_comments)

--- a/main.py
+++ b/main.py
@@ -31,8 +31,10 @@ print_markdown(
 )
 
 """
+-
 Load .env file if exists. If it doesnt exist, print a warning and launch the setup wizard.
 If there is a .env file, check if the required variables are set. If not, print a warning and launch the setup wizard.
+-
 """
 
 client_id = os.getenv("REDDIT_CLIENT_ID")

--- a/video_creation/voices.py
+++ b/video_creation/voices.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from mutagen.mp3 import MP3
 from utils.console import print_step, print_substep
 from rich.progress import track
+import re
 
 
 def save_text_to_mp3(reddit_obj):
@@ -25,7 +26,9 @@ def save_text_to_mp3(reddit_obj):
         # ! Stop creating mp3 files if the length is greater than 50 seconds. This can be longer, but this is just a good starting point
         if length > 50:
             break
-        tts = gTTS(text=comment["comment_body"], lang="en", slow=False)
+        comment=comment["comment_body"]
+        text=re.sub('((http|https)\:\/\/)?[a-zA-Z0-9\.\/\?\:@\-_=#]+\.([a-zA-Z]){2,6}([a-zA-Z0-9\.\&\/\?\:@\-_=#])*', '', comment)
+        tts = gTTS(text, lang="en", slow=False)
         tts.save(f"assets/mp3/{idx}.mp3")
         length += MP3(f"assets/mp3/{idx}.mp3").info.length
 


### PR DESCRIPTION
There is an often issue where when commentators link to another site, then tts will read out the link in its entirety. It is annoying and can ruin a good thread. So I fixed it, this PR uses Regex to filter that stuff out.