### PR TITLE
Bug fix and minor code cleanup (Read description)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ import os
 import time
 from utils.console import print_markdown
 from utils.console import print_step
-from utils.console import print_substep
 from rich.console import Console
 from utils.loader import Loader
 from os.path import exists
@@ -90,8 +89,13 @@ console.log("Attempting to save your credentials...")
 loader = Loader("Saving Credentials...", "Done!").start()
  # you can also put a while loop here, e.g. while VideoIsBeingMade == True: ...
 time.sleep(0.5)
-console.log("Removing old .env file...")
-os.remove(".env")
+
+try:
+	console.log("Removing old .env file...")
+	os.remove(".env")
+except:
+	console.log("No .env file found.")
+
 time.sleep(0.5)
 console.log("Creating new .env file...")
 with open('.env', 'a') as f:

--- a/setup.py
+++ b/setup.py
@@ -90,10 +90,10 @@ loader = Loader("Saving Credentials...", "Done!").start()
  # you can also put a while loop here, e.g. while VideoIsBeingMade == True: ...
 time.sleep(0.5)
 
-try:
+if os.path.exists('.env'):
 	console.log("Removing old .env file...")
 	os.remove(".env")
-except:
+else:
 	console.log("No .env file found.")
 
 time.sleep(0.5)


### PR DESCRIPTION
I found a bug where the setup wizard would fail if a .env file did not exist. The reason for the bug happens when os.remove is called on a file that does not exist, and will then throw an error.

- It now checks if .env exists before trying to delete it
- Removed unused import statement from setup.py