### PR TITLE
Limits the length of video by number of seconds.

### DIFF
--- a/main.py
+++ b/main.py
@@ -88,7 +88,7 @@ console.log("[bold green]Enviroment Variables are set! Continuing...")
 
 if configured:
     reddit_object = get_subreddit_threads()
-    length, number_of_comments = save_text_to_mp3(reddit_object)
+    length, number_of_comments, indices_of_skipped_comments = save_text_to_mp3(reddit_object)
     download_screenshots_of_reddit_posts(
         reddit_object, number_of_comments, os.getenv("THEME", "light")
     )
@@ -97,4 +97,4 @@ if configured:
         noerror = chop_background_video(length, vidpath)
         if noerror is True:
             break
-    final_video = make_final_video(number_of_comments)
+    final_video = make_final_video(number_of_comments, indices_of_skipped_comments)

--- a/video_creation/final_video.py
+++ b/video_creation/final_video.py
@@ -17,13 +17,26 @@ import os
 W, H = 1080, 1920
 
 
-def make_final_video(number_of_clips):
+def make_final_video(number_of_clips, indices_of_skipped_comments):
 
     # Calls opacity from the .env
     load_dotenv()
     opacity = os.getenv("OPACITY")
 
     print_step("Creating the final video...")
+    
+
+    # remove longer audio clips and their respective images
+    counter = 0
+    for i in range(0,number_of_clips):
+        if i in indices_of_skipped_comments:
+            os.remove(f"assets/mp3/{i}.mp3")
+            os.remove(f"assets/png/comment_{i}.png")
+        else:
+            os.rename(f"assets/mp3/{i}.mp3", f"assets/mp3/{counter}.mp3")
+            os.rename(f"assets//png/comment_{i}.png", f"assets//png/comment_{counter}.png")
+            counter+=1
+    number_of_clips-=len(indices_of_skipped_comments)
 
     VideoFileClip.reW = lambda clip: clip.resize(width=W)
     VideoFileClip.reH = lambda clip: clip.resize(width=H)

--- a/video_creation/voices.py
+++ b/video_creation/voices.py
@@ -15,7 +15,8 @@ def save_text_to_mp3(reddit_obj):
     """
     print_step("Saving Text to MP3 files...")
     length = 0
-
+    skipped_idx = []
+    
     # Create a folder for the mp3 files.
     Path("assets/mp3").mkdir(parents=True, exist_ok=True)
 
@@ -33,6 +34,7 @@ def save_text_to_mp3(reddit_obj):
         tts.save("assets/mp3/posttext.mp3")
         length += MP3("assets/mp3/posttext.mp3").info.length
 
+    max_length_in_seconds = 60
     for idx, comment in track(enumerate(reddit_obj["comments"]), "Saving..."):
         # ! Stop creating mp3 files if the length is greater than 50 seconds. This can be longer, but this is just a good starting point
         if length > 50:
@@ -42,7 +44,12 @@ def save_text_to_mp3(reddit_obj):
         tts = gTTS(text, lang="en", slow=False)
         tts.save(f"assets/mp3/{idx}.mp3")
         length += MP3(f"assets/mp3/{idx}.mp3").info.length
+        
+        # doesn't allow length to exceed max_length_in_seconds seconds
+        if length > max_length_in_seconds:
+            length -= MP3(f"assets/mp3/{idx}.mp3").info.length
+            skipped_idx.append(idx)
 
     print_substep("Saved Text to MP3 files successfully.", style="bold green")
     # ! Return the index so we know how many screenshots of comments we need to make.
-    return length, idx
+    return length, idx, skipped_idx

--- a/video_creation/voices.py
+++ b/video_creation/voices.py
@@ -16,6 +16,8 @@ def save_text_to_mp3(reddit_obj):
     """
     print_step("Saving Text to MP3 files...")
     length = 0
+    min_length = 50 # min length of video in seconds, Please note video may be shorter due to lack of comments!!
+    max_length = 60 # max length of video in seconds
     skipped_idx = []
     
     # Create a folder for the mp3 files.
@@ -34,16 +36,18 @@ def save_text_to_mp3(reddit_obj):
         tts = gTTS(text=reddit_obj["thread_post"], lang="en", slow=False)
         tts.save("assets/mp3/posttext.mp3")
         length += MP3("assets/mp3/posttext.mp3").info.length
+ 
+    if length > max_length:
+        print_substep(f"length before adding comments is {length} seconds please increase the max length")
+        exit()
 
-
-    max_length_in_seconds = 60
     for idx, comment in track(enumerate(reddit_obj["comments"])):
 
         #allow user to see what comment is being saved
         print_substep(f"Saving MP3 {idx + 1} ")
 
         # ! Stop creating mp3 files if the length is greater than 50 seconds. This can be longer, but this is just a good starting point
-        if length > 50:
+        if length > min_length:
             break
         comment=comment["comment_body"]
         text=re.sub('((http|https)\:\/\/)?[a-zA-Z0-9\.\/\?\:@\-_=#]+\.([a-zA-Z]){2,6}([a-zA-Z0-9\.\&\/\?\:@\-_=#])*', '', comment)
@@ -52,7 +56,7 @@ def save_text_to_mp3(reddit_obj):
         length += MP3(f"assets/mp3/{idx}.mp3").info.length
         
         # doesn't allow length to exceed max_length_in_seconds seconds
-        if length > max_length_in_seconds:
+        if length > max_length:
             length -= MP3(f"assets/mp3/{idx}.mp3").info.length
             skipped_idx.append(idx)
 


### PR DESCRIPTION
Adds Feature:
- Limits the length of clip by number of seconds by changing  "max_length" and "min_length" variable in voices.py
- The video produced will be in range of whatever "max_length" and "min_length" are set to.
- The video will skip over the comments that exceed the max length while adding only those that don't.
- Please not sometimes video produced will be smaller than min length due to lack of comments.

Fixes #379
Fixed #414
Fixed #433
