### PR TITLE
Add TTS for AWS Polly

### DIFF
--- a/tts/aws_polly.py
+++ b/tts/aws_polly.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+from boto3 import Session
+from botocore.exceptions import BotoCoreError, ClientError
+import sys
+
+max_chars = 0
+
+def run(text, filepath):
+    session = Session(profile_name="polly")
+    polly = session.client("polly")
+
+    try:
+    # Request speech synthesis
+        response = polly.synthesize_speech(Text=text, OutputFormat="mp3",
+                                            VoiceId="Joanna", Engine = 'neural')
+    except (BotoCoreError, ClientError) as error:
+        # The service returned an error, exit gracefully
+        print(error)
+        sys.exit(-1)
+
+    # Access the audio stream from the response
+    if "AudioStream" in response:
+        file = open(filepath, 'wb')
+        file.write(response['AudioStream'].read())
+        file.close()
+        #print_substep(f"Saved Text {idx} to MP3 files successfully.", style="bold green")
+
+    else:
+        # The response didn't contain audio data, exit gracefully
+        print("Could not stream audio")
+        sys.exit(-1)

--- a/video_creation/voices.py
+++ b/video_creation/voices.py
@@ -3,10 +3,15 @@ import os
 from utils.console import print_step, print_substep, print_table
 from tts.engine_wrapper import TTSEngine
 import tts.google_translate
+import tts.aws_polly
+
 
 
 ## Add your provider here in the dictionary below
-TTSProviders = {"GoogleTranslate": tts.google_translate}
+TTSProviders = {
+    "GoogleTranslate": tts.google_translate,
+    "AWSPolly": tts.aws_polly
+    }
 
 
 def save_text_to_mp3(reddit_obj):


### PR DESCRIPTION
This PR adds AWS Polly as TTS option adding a huge number of voices and languages to use. 
It will require having an AWS account and credentials with AWS Polly permissions. 

This follows the template from: https://github.com/elebumm/RedditVideoMakerBot/blob/feat/add-tts-generics/tts/example_tts.py

The code for TTS according to AWS is from their example here: https://docs.aws.amazon.com/polly/latest/dg/SynthesizeSpeechSamplePython.html

This is all the voices and languages available from AWS Polly: https://docs.aws.amazon.com/polly/latest/dg/voicelist.html 

Test video:

https://user-images.githubusercontent.com/8630545/172675714-7bf64350-5d35-4f69-bf0b-90ff59c0c524.mp4
