### PR TITLE
Change submission.url to submission.permalink

### DIFF
--- a/reddit/subreddit.py
+++ b/reddit/subreddit.py
@@ -60,7 +60,7 @@ def get_subreddit_threads():
     print_substep(f"Video will be: {submission.title} :thumbsup:")
     console.log("Getting video comments...")
     try:
-        content["thread_url"] = submission.url
+        content["thread_url"] = submission.permalink
         content["thread_title"] = submission.title
         content["thread_post"] = submission.selftext
         content["comments"] = []

--- a/reddit/subreddit.py
+++ b/reddit/subreddit.py
@@ -60,7 +60,7 @@ def get_subreddit_threads():
     print_substep(f"Video will be: {submission.title} :thumbsup:")
     console.log("Getting video comments...")
     try:
-        content["thread_url"] = f"https://reddit.com/{submission.permalink}"
+        content["thread_url"] = f"https://reddit.com{submission.permalink}"
         content["thread_title"] = submission.title
         content["thread_post"] = submission.selftext
         content["comments"] = []

--- a/reddit/subreddit.py
+++ b/reddit/subreddit.py
@@ -60,7 +60,7 @@ def get_subreddit_threads():
     print_substep(f"Video will be: {submission.title} :thumbsup:")
     console.log("Getting video comments...")
     try:
-        content["thread_url"] = f"https:reddit.com/{submission.permalink}"
+        content["thread_url"] = f"https://reddit.com/{submission.permalink}"
         content["thread_title"] = submission.title
         content["thread_post"] = submission.selftext
         content["comments"] = []

--- a/reddit/subreddit.py
+++ b/reddit/subreddit.py
@@ -60,7 +60,7 @@ def get_subreddit_threads():
     print_substep(f"Video will be: {submission.title} :thumbsup:")
     console.log("Getting video comments...")
     try:
-        content["thread_url"] = submission.permalink
+        content["thread_url"] = f"https:reddit.com/{submission.permalink}"
         content["thread_title"] = submission.title
         content["thread_post"] = submission.selftext
         content["comments"] = []


### PR DESCRIPTION
Changed submission.url to submission.permalink to fix crashes when a post only has a link and no description as praw states it goes to the link with .url instead of going to the post