### PR TITLE
Fix broken TMRRW logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,14 @@ All done WITHOUT video editing or asset compiling. Just pure ✨programming magi
 
 Created by Lewis Menelaws & [TMRRW](https://tmrrwinc.ca)
 
-[<picture>
-
+<a target="_blank" href="https://tmrrwinc.ca">
+<picture>
   <source media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/6053155/170528535-e274dc0b-7972-4b27-af22-637f8c370133.png">
   <source media="(prefers-color-scheme: light)" srcset="https://user-images.githubusercontent.com/6053155/170528582-cb6671e7-5a2f-4bd4-a048-0e6cfa54f0f7.png">
   <img src="https://user-images.githubusercontent.com/6053155/170528582-cb6671e7-5a2f-4bd4-a048-0e6cfa54f0f7.png" width="350">
-</picture>](https://tmrrwinc.ca)
+</picture>
+
+</a>
 
 ## Video Explainer
 [![lewisthumbnail](https://user-images.githubusercontent.com/6053155/173631669-1d1b14ad-c478-4010-b57d-d79592a789f2.png)


### PR DESCRIPTION
Add href to TMRRW logo to properly redirect without other characters displaying

Mine versus the current one:
![Scr](https://github.com/owengaspard/scr/blob/main/Screenshot%20from%202022-06-16%2001-01-28.png?raw=true)