### PR TITLE
Allow (Some) Environment Variables to be blank

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,4 +169,4 @@ results/*
 reddit-bot-351418-5560ebc49cac.json
 /.idea
 *.pyc
-/video_creation/data/videos.json
+video_creation/data/videos.json

--- a/TTS/swapper.py
+++ b/TTS/swapper.py
@@ -12,7 +12,11 @@ CHOICE_DIR = {"tiktok": TikTok, "gtts": GTTS, 'polly': POLLY}
 class TTS:
     def __new__(cls):
         load_dotenv()
-        CHOICE = getenv("TTsChoice").casefold()
+        try:
+            CHOICE = getenv("TTsChoice").casefold()
+        except AttributeError:
+            print_substep("None defined. Defaulting to 'polly.'")
+            CHOICE = "polly"
         valid_keys = [key.lower() for key in CHOICE_DIR.keys()]
         if CHOICE not in valid_keys:
             raise ValueError(

--- a/reddit/subreddit.py
+++ b/reddit/subreddit.py
@@ -7,6 +7,8 @@ from utils.subreddit import get_subreddit_undone
 from utils.videos import check_done
 from praw.models import MoreComments
 
+import re
+
 TEXT_WHITELIST = set("abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 1234567890")
 
 
@@ -44,12 +46,18 @@ def get_subreddit_threads():
     print_step("Getting subreddit threads...")
     if not getenv(
         "SUBREDDIT"
-    ):  # note to self. you can have multiple subreddits via reddit.subreddit("redditdev+learnpython")
-        subreddit = reddit.subreddit(
-            input("What subreddit would you like to pull from? ")
-        )  # if the env isnt set, ask user
+    ):  # note to self. you can have multiple subreddits via reddit.subreddit("redditdev+learnpython")    
+        try:
+                subreddit = reddit.subreddit(
+                    re.sub(r"r\/", "",input("What subreddit would you like to pull from? "))
+                )
+        except ValueError:
+            subreddit = reddit.subreddit("askreddit")
+            print_substep("Subreddit not defined. Using AskReddit.")
     else:
-        print_substep(f"Using subreddit: r/{getenv('SUBREDDIT')} from environment variable config")
+        print_substep(
+            f"Using subreddit: r/{getenv('SUBREDDIT')} from environment variable config"
+        )
         subreddit = reddit.subreddit(
             getenv("SUBREDDIT")
         )  # Allows you to specify in .env. Done for automation purposes.

--- a/utils/subreddit.py
+++ b/utils/subreddit.py
@@ -14,8 +14,12 @@ def get_subreddit_undone(submissions: List, subreddit):
         if already_done(done_videos, submission):
             continue
         if submission.over_18:
-            if getenv("ALLOW_NSFW").casefold() == "false":
-                print_substep("NSFW Post Detected. Skipping...")
+            try:
+                if getenv("ALLOW_NSFW").casefold() == "false":
+                    print_substep("NSFW Post Detected. Skipping...")
+                    continue
+            except AttributeError:
+                print_substep("NSFW settings not defined. Skipping NSFW post...")
                 continue
         return submission
     print('all submissions have been done going by top submission order')


### PR DESCRIPTION
This feature was in an old version but was removed in a recent PR. It allows the env variable `SUBREDDIT` to be blank and the user input to be blank which will default to AskReddit instead of an error. It also automatically filters out any special characters (in case someone types r/) from the subreddit using re.

As of commit [ed86199](https://github.com/elebumm/RedditVideoMakerBot/pull/549/commits/ed86199141cdd2ceaf196c1c66c70b5f703a1e5b), TTsChoice and ALLOW_NSFW can also be blank. `TTsChoice` defaults to `polly`, and `ALLOW_NSFW` defaults to `False`.

![Terminal Screenshot](https://github.com/owengaspard/scr/blob/main/Screenshot%20from%202022-06-18%2011-11-42.png?raw=true)