### PR TITLE
chore(*): Add devcontainer vscode support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.238.0/containers/docker-existing-dockerfile
+{
+	"name": "Existing Dockerfile",
+
+	// Sets the run context to one level up instead of the .devcontainer folder.
+	"context": "..",
+
+	// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+	"dockerFile": "../Dockerfile",
+	
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"ms-python.python"
+	],
+
+	// Install OS dependencies
+	"postCreateCommand": "apt-get update && apt -qq install -y sox && apt-get install -y libsox-fmt-all"
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Main.py",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}/main.py",
+            "console": "integratedTerminal",
+            "justMyCode": true
+        }
+    ]
+}


### PR DESCRIPTION
This commit enables devs to have their dev environment set up as Infrastructure As Code (IAC) utilising the existing Dockerfile. 

If a dev has the following three things installed on their machine this will work: 

- Docker
- vscode
- The Microsoft 'Remote - Containers' extension for vscode

Upon opening the repo in vscode devs will be prompted to reopen using the container. From there they can then debug using the built-in debugger in vscode.

Nothing else is needed to get the code running on their PC. All dev requirements can then be updated in the repository for all devs.