### PR TITLE
Restart/rerun the main.py script automatically

### DIFF
--- a/restart.py
+++ b/restart.py
@@ -1,0 +1,6 @@
+import os
+while 1:
+    os.system("python3 main.py")
+    print("Restarting......")
+
+# if you want to restart the main Script automatically 'n' number of times then rewrite the while loop to run 'n' times.


### PR DESCRIPTION
This will rerun or **re-execute the main.py script automatically** once it disrupted or killed by any error.

When I try to execute the main script multiple times by using **TIMES_TO_RUN="n"** feature sometimes the script stopped by some errors like timeout or sox not found, then I need to restart the script again and again so I wrote this to automate the restarting part if any error or timeout occures. if anyone wants to rerun the script for n number of times then they can by rewriting the while loop to run exactly n times.
and one more thing I found is that sometimes some specific reddit thread causes the errors (i don't know why) so try to put **RANDOM_THREAD="yes"** to yes so that it does loop on errors( like the script start -> found error -> got stopped -> restart by restart.py....and so on)