### PR TITLE
python version update to python 3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The only original thing being done is the editing and gathering of all materials
 
 ## Requirements
 
-- Python 3.6+
+- Python 3.7+
 - Playwright (this should install automatically in installation)
 
 ## Installation 👩‍💻


### PR DESCRIPTION
playwright needs python 3.7+ as seen here  https://playwright.dev/python/docs/intro#system-requirements
Getting started | Playwright Python