### PR TITLE
Edited readme for automatic install help

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The only original thing being done is the editing and gathering of all materials
 ## Installation 👩‍💻
 
 1. Clone this repository
-2. 2a **Automatic Install**: Run `python main.py` and type 'yes' to activate the setup assistant.
+2. 2a **Automatic Install**: Run `python setup.py` and type 'yes' to activate the setup assistant.
 
    2b **Manual Install**: Rename `.env.template` to `.env` and replace all values with the appropriate fields. To get Reddit keys (**required**), visit [the Reddit Apps page.](https://www.reddit.com/prefs/apps) TL;DR set up an app that is a "script". Copy your keys into the `.env` file, along with whether your account uses two-factor authentication.
 

--- a/setup.py
+++ b/setup.py
@@ -139,7 +139,7 @@ client_sec = handle_input(
 user = handle_input(
     "Username > ",
     False,
-    r"[_0-9a-zA-Z]+",
+    r"[-_0-9a-zA-Z]+",
     "That is not a valid user",
     3,
     20,


### PR DESCRIPTION
The readme instructed users to run 'python main.py' to automatically install. I have changed this to instruct to use 'python setup.py' as this is the script for automatic installation.