### PR TITLE
Fixing legacy VOICE variables

### DIFF
--- a/TTS/aws_polly.py
+++ b/TTS/aws_polly.py
@@ -35,9 +35,9 @@ class AWSPolly:
         if random_voice:
             voice = self.randomvoice()
         else:
-            if not os.getenv("VOICE"):
+            if not os.getenv("AWS_VOICE"):
                 return ValueError(
-                    f"Please set the environment variable VOICE to a valid voice. options are: {voices}"
+                    f"Please set the environment variable AWS_VOICE to a valid voice. options are: {voices}"
                 )
             voice = str(os.getenv("AWS_VOICE")).capitalize()
         try:

--- a/TTS/streamlabs_polly.py
+++ b/TTS/streamlabs_polly.py
@@ -35,9 +35,9 @@ class StreamlabsPolly:
         if random_voice:
             voice = self.randomvoice()
         else:
-            if not os.getenv("VOICE"):
+            if not os.getenv("STREAMLABS_VOICE"):
                 return ValueError(
-                    f"Please set the environment variable VOICE to a valid voice. options are: {voices}"
+                    f"Please set the environment variable STREAMLABS_VOICE to a valid voice. options are: {voices}"
                 )
             voice = str(os.getenv("STREAMLABS_VOICE")).capitalize()
         body = {"voice": voice, "text": text, "service": "polly"}


### PR DESCRIPTION
# Description

Fixing legacy VOICE variables that caused lot of issues if TTSCHOICE set to AWS_VOICE or STREAMLABS_VOICE

# Issue Fixes

Fixes #821
Fixes #835
and list goes on.

# Checklist:

- [x] I am pushing changes to the **develop** branch
- [x] I am using the recommended development environment
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have formatted and linted my code using python-black and pylint
- [x] I have cleaned up unnecessary files
- [x] My changes generate no new warnings
- [x] My changes follow the existing code-style
- [x] My changes are relevant to the project

# Any other information (e.g how to test the changes)

If you set your TTSCHOICE to StreamlabsPolly, TTS/streamlabs_polly.py is trying to get os.getenv("VOICE"), but legacy VOICE is removed. With this changes it should be okay.


Also there is still a "VOICE": "en_us_001" value in utils/config.py but it's for default env. I didn't remove it but since VOICE is removed from .env we can remove it as well.