### PR TITLE
Fix: cutting long file names to avoid errors when saving

### DIFF
--- a/video_creation/final_video.py
+++ b/video_creation/final_video.py
@@ -29,7 +29,7 @@ def name_normalize(name: str) -> str:
     name = re.sub(r"(\d+)\s?\/\s?(\d+)", r"\1 of \2", name)
     name = re.sub(r"(\w+)\s?\/\s?(\w+)", r"\1 or \2", name)
     name = re.sub(r"\/", r"", name)
-    name[:70]
+    name[:30]
 
     lang = settings.config["reddit"]["thread"]["post_lang"]
     if lang:

--- a/video_creation/final_video.py
+++ b/video_creation/final_video.py
@@ -29,11 +29,11 @@ def name_normalize(name: str) -> str:
     name = re.sub(r"(\d+)\s?\/\s?(\d+)", r"\1 of \2", name)
     name = re.sub(r"(\w+)\s?\/\s?(\w+)", r"\1 or \2", name)
     name = re.sub(r"\/", r"", name)
+    name[:70]
 
     lang = settings.config["reddit"]["thread"]["post_lang"]
     if lang:
         import translators as ts
-
         print_substep("Translating filename...")
         translated_name = ts.google(name, to_language=lang)
         return translated_name


### PR DESCRIPTION
# Description

I've added a limit into the mp4 file name to avoid errors when saving files with very long filenames due to a long reddit post title.

# Issue Fixes

This does not fix any issue I've seen in the repo but fixes a problem I've encountered when testing the code.

None

# Checklist:

- [ x] I am pushing changes to the **develop** branch
- [ x] I am using the recommended development environment
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have formatted and linted my code using python-black and pylint
- [ x] I have cleaned up unnecessary files
- [ x] My changes generate no new warnings
- [ x] My changes follow the existing code-style
- [ x] My changes are relevant to the project

# Any other information (e.g how to test the changes)

In this particular post (https://www.reddit.com/r/explainlikeimfive/comments/vxwol7/eli5_in_light_of_everyone_losing_their_minds_over/) the filename generated is too long and throws an error when saving. 
This modification to the name_normalize() method solves this.
