### PR TITLE
Fix: Hide the "Click to see NSFW" button

### DIFF
--- a/video_creation/screenshot_downloader.py
+++ b/video_creation/screenshot_downloader.py
@@ -50,7 +50,7 @@ def download_screenshots_of_reddit_posts(reddit_object: dict, screenshot_num: in
             print_substep("Post is NSFW. You are spicy...")
             page.locator('[data-testid="content-gate"] button').click()
             page.locator(
-                '[data-click-id="text"] button'
+                'text=Click to see nsfw'
             ).click()  # Remove "Click to see nsfw" Button in Screenshot
 
         # translate code


### PR DESCRIPTION
# Description

The page locator couldn't find the "Click to see NSFW" button. It was still visible on screenshots. After changing it to look for text (innerHTML), instead, it worked. I'm not the only person that ran across this bug - #368.

Solution example:

![title](https://user-images.githubusercontent.com/61630074/179036824-70ebe535-8a7f-4cd5-981a-5e43d0e702be.png)

# Issue Fixes

None

# Checklist:

- [x] I am pushing changes to the **develop** branch
- [x] I am using the recommended development environment
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have formatted and linted my code using python-black and pylint
- [x] I have cleaned up unnecessary files
- [x] My changes generate no new warnings
- [x] My changes follow the existing code-style
- [x] My changes are relevant to the project

# Any other information (e.g how to test the changes)

None
