### PR TITLE
Fix: Hide the "Click to see NSFW" button

### DIFF
--- a/video_creation/screenshot_downloader.py
+++ b/video_creation/screenshot_downloader.py
@@ -49,6 +49,7 @@ def download_screenshots_of_reddit_posts(reddit_object: dict, screenshot_num: in
 
             print_substep("Post is NSFW. You are spicy...")
             page.locator('[data-testid="content-gate"] button').click()
+            page.wait_for_load_state() # Wait for page to fully load
 
             if page.locator('[data-click-id="text"] button').is_visible():
                 page.locator(


### PR DESCRIPTION
# Description

The button "Click to see NSFW" was visible on screenshots. Clicking on the 'Yes' button on the first screen triggers reload, so by making Playwright wait for the page to fully load, we can make sure the button will be clicked. 

Thanks to @Drugsosos who thought about it - #991.

# Issue Fixes

None

# Checklist:

- [x] I am pushing changes to the **develop** branch
- [x] I am using the recommended development environment
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have formatted and linted my code using python-black and pylint
- [x] I have cleaned up unnecessary files
- [x] My changes generate no new warnings
- [x] My changes follow the existing code-style
- [x] My changes are relevant to the project

# Any other information (e.g how to test the changes)

To test changes you just have to run the script with an NSFW post and check if the title screenshot doesn't have the "Click to see NSFW" button.
