### PR TITLE
change AWS and GTTS max_chars

### DIFF
--- a/TTS/GTTS.py
+++ b/TTS/GTTS.py
@@ -8,7 +8,7 @@ max_chars = 0
 
 class GTTS:
     def __init__(self):
-        self.max_chars = 0
+        self.max_chars = 5000
         self.voices = []
 
     def run(self, text, filepath):

--- a/TTS/aws_polly.py
+++ b/TTS/aws_polly.py
@@ -26,7 +26,7 @@ voices = [
 
 class AWSPolly:
     def __init__(self):
-        self.max_chars = 100000
+        self.max_chars = 3000
         self.voices = voices
 
     def run(self, text, filepath, random_voice: bool = False):

--- a/TTS/aws_polly.py
+++ b/TTS/aws_polly.py
@@ -26,7 +26,7 @@ voices = [
 
 class AWSPolly:
     def __init__(self):
-        self.max_chars = 0
+        self.max_chars = 100000
         self.voices = voices
 
     def run(self, text, filepath, random_voice: bool = False):


### PR DESCRIPTION

# Description

previously aws TTS did not read out comments correctly and only made weird sounds with super short mp3s. This fixes the problem and allows the full comment to be read.

# Issue Fixes

<!-- Fixes #(issue) if relevant-->

None

# Checklist:

- [x] I am pushing changes to the **develop** branch
- [x] I am using the recommended development environment
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have formatted and linted my code using python-black and pylint
- [x] I have cleaned up unnecessary files
- [x] My changes generate no new warnings
- [x] My changes follow the existing code-style
- [x] My changes are relevant to the project

# Any other information (e.g how to test the changes)

None
