### PR TITLE
Feat: Created option to add transition between comments

### DIFF
--- a/utils/.config.template.toml
+++ b/utils/.config.template.toml
@@ -26,6 +26,7 @@ theme = { optional = false, default = "dark", example = "light", options = ["dar
 ], explanation = "sets the Reddit theme, either LIGHT or DARK" }
 times_to_run = { optional = false, default = 1, example = 2, explanation = "used if you want to run multiple times. set to an int e.g. 4 or 29 or 1", type = "int", nmin = 1, oob_error = "It's very hard to run something less than once." }
 opacity = { optional = false, default = 0.9, example = 0.8, explanation = "Sets the opacity of the comments when overlayed over the background", type = "float", nmin = 0, nmax = 1, oob_error = "The opacity HAS to be between 0 and 1", input_error = "The opacity HAS to be a decimal number between 0 and 1" }
+transition = { optional = true, default = 0.2, example = 0.2, explanation = "Sets the transition time (in seconds) between the comments. Set to 0 if you want to disable it.", type = "float", nmin = 0, nmax = 2, oob_error = "The transition HAS to be between 0 and 2", input_error = "The opacity HAS to be a decimal number between 0 and 2" }
 storymode = { optional = true, type = "bool", default = false, example = false, options = [true,
     false,
 ], explanation = "not yet implemented" }

--- a/video_creation/final_video.py
+++ b/video_creation/final_video.py
@@ -66,6 +66,7 @@ def make_final_video(
     VideoFileClip.reW = lambda clip: clip.resize(width=W)
     VideoFileClip.reH = lambda clip: clip.resize(width=H)
     opacity = settings.config["settings"]["opacity"]
+    transition = settings.config["settings"]["transition"]
     background_clip = (
         VideoFileClip("assets/temp/background.mp4")
         .without_audio()
@@ -84,12 +85,15 @@ def make_final_video(
     image_clips = []
     # Gather all images
     new_opacity = 1 if opacity is None or float(opacity) >= 1 else float(opacity)
+    new_transition = 0 if transition is None or float(transition) > 2 else float(transition)
     image_clips.insert(
         0,
         ImageClip("assets/temp/png/title.png")
         .set_duration(audio_clips[0].duration)
         .resize(width=W - 100)
-        .set_opacity(new_opacity),
+        .set_opacity(new_opacity)
+        .crossfadein(new_transition)
+        .crossfadeout(new_transition),
     )
 
     for i in range(0, number_of_clips):
@@ -98,6 +102,8 @@ def make_final_video(
             .set_duration(audio_clips[i + 1].duration)
             .resize(width=W - 100)
             .set_opacity(new_opacity)
+            .crossfadein(new_transition)
+            .crossfadeout(new_transition)
         )
 
     # if os.path.exists("assets/mp3/posttext.mp3"):


### PR DESCRIPTION
# Description

I created an option to add a transition (fade-in and fade-out) between the images of comments. Comments appear smoothly with the customizable length of transitions. You can set the length of the transitions in the range of 0-2 seconds, but I think anything bigger than 0.5 looks bad (best results with default value - 0.2).

### Example:

https://user-images.githubusercontent.com/61630074/179804800-9c927298-fddf-46b9-9a01-3a56259be180.mp4

# Issue Fixes

<!-- Fixes #(issue) if relevant-->

None

# Checklist:

- [x] I am pushing changes to the **develop** branch
- [x] I am using the recommended development environment
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have formatted and linted my code using python-black and pylint
- [x] I have cleaned up unnecessary files
- [x] My changes generate no new warnings
- [x] My changes follow the existing code-style
- [x] My changes are relevant to the project

# Any other information (e.g how to test the changes)

None