### PR TITLE
prevent last comment being cut off in the middle

### DIFF
--- a/TTS/engine_wrapper.py
+++ b/TTS/engine_wrapper.py
@@ -127,8 +127,7 @@ class TTSEngine:
         #     self.length += sox.file_info.duration(f"{self.path}/{filename}.mp3")
         try:
             clip = AudioFileClip(f"{self.path}/{filename}.mp3")
-            if clip.duration + self.length < self.max_length:
-                self.last_clip_length = clip.duration
+            self.last_clip_length = clip.duration
             self.length += clip.duration
             clip.close()
         except:


### PR DESCRIPTION
# Description

with the recent changes that fixed the freeze frames at the end of the videos, a new bug was introduced that cut off comments at the end of the video. This fix will prevent that and read the comment fully instead

# Checklist:

- [x] I am pushing changes to the **develop** branch
- [x] I am using the recommended development environment
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have formatted and linted my code using python-black and pylint
- [x] I have cleaned up unnecessary files
- [x] My changes generate no new warnings
- [x] My changes follow the existing code-style
- [x] My changes are relevant to the project

