### PR TITLE
Add video_length to config template

### DIFF
--- a/TTS/engine_wrapper.py
+++ b/TTS/engine_wrapper.py
@@ -13,7 +13,7 @@ from utils.console import print_step, print_substep
 from utils.voice import sanitize_text
 from utils import settings
 
-DEFAULT_MAX_LENGTH: int = 50  # video length variable
+
 
 
 class TTSEngine:
@@ -24,7 +24,6 @@ class TTSEngine:
         tts_module          : The TTS module. Your module should handle the TTS itself and saving to the given path under the run method.
         reddit_object         : The reddit object that contains the posts to read.
         path (Optional)       : The unix style path to save the mp3 files to. This must not have leading or trailing slashes.
-        max_length (Optional) : The maximum length of the mp3 files in total.
 
     Notes:
         tts_module must take the arguments text and filepath.
@@ -35,13 +34,12 @@ class TTSEngine:
         tts_module,
         reddit_object: dict,
         path: str = "assets/temp/mp3",
-        max_length: int = DEFAULT_MAX_LENGTH,
         last_clip_length: int = 0,
     ):
         self.tts_module = tts_module()
         self.reddit_object = reddit_object
         self.path = path
-        self.max_length = max_length
+        self.max_length = settings.config["settings"]["video_length"]
         self.length = 0
         self.last_clip_length = last_clip_length
 

--- a/utils/.config.template.toml
+++ b/utils/.config.template.toml
@@ -21,6 +21,7 @@ min_comments = { default = 20, optional = false, nmin = 15, type = "int", explan
 allow_nsfw = { optional = false, type = "bool", default = false, example = false, options = [true,
     false,
 ], explanation = "Whether to allow NSFW content, True or False" }
+video_length = { default = 50, optional = false, nmin = 20, nmax = 3600, type = "int", explanation = "The minimum length of a video in seconds. default is 50", example = 25, oob_error = "the length of the video should be between 20 and 3600 seconds" }
 theme = { optional = false, default = "dark", example = "light", options = ["dark",
     "light",
 ], explanation = "sets the Reddit theme, either LIGHT or DARK" }


### PR DESCRIPTION
# Description

Added video_length to config template, so user can now specify the minimum video length in seconds.

# Issue Fixes

Fixes issue #628 

# Checklist:

- [ ] I am pushing changes to the **develop** branch
- [ ] I am using the recommended development environment
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have formatted and linted my code using python-black and pylint
- [ ] I have cleaned up unnecessary files
- [ ] My changes generate no new warnings
- [ ] My changes follow the existing code-style
- [ ] My changes are relevant to the project

# Any other information (e.g how to test the changes)

None
