### PR TITLE
fix: install.sh might break python environments

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -62,7 +62,7 @@ function install_macos(){
     fi
     # Install the required packages
     echo "Installing required Packages" 
-    if [! commad --version python3 &> /dev/null ]; then
+    if [! command --version python3 &> /dev/null ]; then
 	    echo "Installing python3"
 	    brew install python@3.10
     else

--- a/install.sh
+++ b/install.sh
@@ -62,7 +62,13 @@ function install_macos(){
     fi
     # Install the required packages
     echo "Installing required Packages" 
-    brew install python@3.10 tcl-tk python-tk
+    if [! commad --version python3 &> /dev/null ]; then
+	    echo "Installing python3"
+	    brew install python@3.10
+    else
+	    echo "python3 already installed."
+    fi
+    brew install tcl-tk python-tk
 } 
 
 # Function to install for arch (and other forks like manjaro)


### PR DESCRIPTION
# Description

Fixes an issue that might break python environments on macOS.

# Issue Fixes

Fixes #1133 

# Checklist:

- [x] I am pushing changes to the **develop** branch
- [x] I am using the recommended development environment
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas [N/A]
- [ ] I have formatted and linted my code using python-black and pylint [N/A]
- [ ] I have cleaned up unnecessary files [N/A]
- [x] My changes generate no new warnings
- [x] My changes follow the existing code-style
- [x] My changes are relevant to the project

# Any other information (e.g how to test the changes)

Test the changes on a macOS 10.15 or higher system as follows:

```bash
$ chmod +x install.sh
$ ./install.sh -l (or equivalent option)
```

## Sidenote

Been a while since I looked at this. New maintainers definitely are doing a great job!