### PR TITLE
Fix: Correct video length

### DIFF
--- a/TTS/engine_wrapper.py
+++ b/TTS/engine_wrapper.py
@@ -132,6 +132,7 @@ class TTSEngine:
                       "-c copy " + f"{self.path}/{filename}.mp3")
             clip = AudioFileClip(f"{self.path}/{filename}.mp3")
             self.length += clip.duration
+            self.last_clip_length = clip.duration
             clip.close()
             try:
                 name = [f"{filename}_no_silence.mp3", "silence.mp3", f"{filename}.txt"]


### PR DESCRIPTION
# Description

Every time I run the script, it leaves extra few seconds after it's done with the last comment (there is only a background video). I found out that it didn't remove the last clip when it exceeded the length limit (`self.last_clip_length` is always `0`). I fixed it by adding one line that correctly changes `self.last_clip_length`.

# Issue Fixes

- Now videos shouldn't exceed the length limit.
- Videos are cut right after the last comment is finished reading.

Fixes #1115 (not sure)

# Examples

**Before:**

https://user-images.githubusercontent.com/61630074/187253117-c26f4dbb-e2fb-4755-a781-47d562d7fd8a.mp4

**After:**

https://user-images.githubusercontent.com/61630074/187254301-d41f5f00-cb37-4cad-bf11-b02b53ed0b58.mp4