### PR TITLE
Update .config.template.toml fix multiple subreddits regex

### DIFF
--- a/utils/.config.template.toml
+++ b/utils/.config.template.toml
@@ -8,7 +8,7 @@ password = { optional = false, nmin = 8, explanation = "The password of your red
 
 [reddit.thread]
 random = { optional = true, options = [true, false, ], default = false, type = "bool", explanation = "If set to no, it will ask you a thread link to extract the thread, if yes it will randomize it. Default: 'False'", example = "True" }
-subreddit = { optional = false, regex = "[_0-9a-zA-Z]+$", nmin = 3, explanation = "What subreddit to pull posts from, the name of the sub, not the URL. You can have multiple subreddits, add an + with no spaces.", example = "AskReddit+Redditdev", oob_error = "A subreddit name HAS to be between 3 and 20 characters" }
+subreddit = { optional = false, regex = "[_0-9a-zA-Z\\+]+$", nmin = 3, explanation = "What subreddit to pull posts from, the name of the sub, not the URL. You can have multiple subreddits, add an + with no spaces.", example = "AskReddit+Redditdev", oob_error = "A subreddit name HAS to be between 3 and 20 characters" }
 post_id = { optional = true, default = "", regex = "^((?!://|://)[+a-zA-Z0-9])*$", explanation = "Used if you want to use a specific post.", example = "urdtfx" }
 max_comment_length = { default = 500, optional = false, nmin = 10, nmax = 10000, type = "int", explanation = "max number of characters a comment can have. default is 500", example = 500, oob_error = "the max comment length should be between 10 and 10000" }
 post_lang = { default = "", optional = true, explanation = "The language you would like to translate to.", example = "es-cr" }


### PR DESCRIPTION
# Description
Minor change to the regex to allow multiple subreddits to be used. Previously, it would prompt the user even if multiple subreddits was entered successfully, and only after in the terminal/CMD if the user entered it again, it would work, for that run of main.py. This solves the issue as there was a missing part of the regex. 

# Issue Fixes
#1193 
#1020 
Probably more issues too, and we have discussed it in the Discord. 

# Checklist:

- [x] I am pushing changes to the **develop** branch
- [x] I am using the recommended development environment
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have formatted and linted my code using python-black and pylint
- [x] I have cleaned up unnecessary files
- [x] My changes generate no new warnings
- [x] My changes follow the existing code-style
- [x] My changes are relevant to the project

# Any other information (e.g how to test the changes)
Change the [reddit.thread] config for "subreddit" in .config.template.toml from regex = "[_0-9a-zA-Z]+$" to regex = "[_0-9a-zA-Z\\+]+$"