### PR TITLE
docs: update minimum python version to 3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The only original thing being done is the editing and gathering of all materials
 
 ## Requirements
 
-- Python 3.9+
+- Python 3.10+
 - Playwright (this should install automatically in installation)
 
 ## Installation 👩‍💻


### PR DESCRIPTION
# Description

Update README with a minimum Python version of 3.10. The `match` keyword was only introduced in 3.10.

# Issue Fixes

Using Python 3.9:
```
  File "/RedditVideoMakerBot/reddit/subreddit.py", line 44
    match e.response.status_code:
          ^
SyntaxError: invalid syntax
```

None

# Checklist:

- [x] I am pushing changes to the **develop** branch
- [x] I am using the recommended development environment
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have formatted and linted my code using python-black and pylint
- [x] I have cleaned up unnecessary files
- [x] My changes generate no new warnings
- [x] My changes follow the existing code-style
- [x] My changes are relevant to the project

# Any other information (e.g how to test the changes)

None
