### PR TITLE
fix: tts blending sentences between paragraphs

### DIFF
--- a/TTS/engine_wrapper.py
+++ b/TTS/engine_wrapper.py
@@ -51,11 +51,18 @@ class TTSEngine:
         self.length = 0
         self.last_clip_length = last_clip_length
 
+    def add_periods(self):  # adds periods to the end of paragraphs (where people often forget to put them) so tts doesn't blend sentences
+        for comment in self.reddit_object["comments"]:
+            comment["comment_body"] = comment["comment_body"].replace('\n', '. ')
+            if comment["comment_body"][-1] != '.': 
+                comment["comment_body"] += '.' 
+
     def run(self) -> Tuple[int, int]:
 
         Path(self.path).mkdir(parents=True, exist_ok=True)
         print_step("Saving Text to MP3 files...")
-
+	
+        self.add_periods()
         self.call_tts("title", process_text(self.reddit_object["thread_title"]))
         # processed_text = ##self.reddit_object["thread_post"] != ""
         idx = None


### PR DESCRIPTION
# Description

In long comments people often don't put full stop at the end of paragraph, which results tts blending the last sentence of one paragraph with the first sentence of the next one. 

For example:
<img width="285" alt="image" src="https://user-images.githubusercontent.com/33136161/217918853-6c2b6509-38a6-424e-b230-95162287c23f.png">
Here tts would pronounce "_Eating out edit_" as one clause, which sounds very confusing.

# Issue Fixes

Function `add_periods()` replaces every "\n" with ". " for tts so now it makes pauses between paragraphs. It also adds a period to the end of comments (if it's not already there) to fix same issue but with different comments instead of different paragraphs.
