### PR TITLE
Sets default voice

### DIFF
--- a/utils/.config.template.toml
+++ b/utils/.config.template.toml
@@ -42,7 +42,7 @@ background_thumbnail_font_size = { optional = true, type = "int", default = 96, 
 background_thumbnail_font_color = { optional = true, default = "255,255,255", example = "255,255,255", explanation = "Font color in RGB format for the thumbnail text" }
 
 [settings.tts]
-voice_choice = { optional = false, default = "tiktok", options = ["streamlabspolly", "tiktok", "googletranslate", "awspolly", "pyttsx", ], example = "tiktok", explanation = "The voice platform used for TTS generation. This can be left blank and you will be prompted to choose at runtime." }
+voice_choice = { optional = false, default = "streamlabspolly", options = ["streamlabspolly", "tiktok", "googletranslate", "awspolly", "pyttsx", ], example = "tiktok", explanation = "The voice platform used for TTS generation. This can be left blank and you will be prompted to choose at runtime." }
 aws_polly_voice = { optional = false, default = "Matthew", example = "Matthew", explanation = "The voice used for AWS Polly" }
 streamlabs_polly_voice = { optional = false, default = "Matthew", example = "Matthew", explanation = "The voice used for Streamlabs Polly" }
 tiktok_voice = { optional = true, default = "en_us_001", example = "en_us_006", explanation = "The voice used for TikTok TTS" }


### PR DESCRIPTION
# Description

As TikTok voice requires additional steps, I think it'd be better to default to streamlabspolly. 

# Issue Fixes

<!-- Fixes #(issue) if relevant-->
Partial Fix: #1489
None

# Checklist:

- [X] I am pushing changes to the **develop** branch
- [X] I am using the recommended development environment
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have formatted and linted my code using python-black and pylint
- [X] I have cleaned up unnecessary files
- [X] My changes generate no new warnings
- [X] My changes follow the existing code-style
- [X] My changes are relevant to the project

# Any other information (e.g how to test the changes)

*Haven't worked on GUI *
