### PR TITLE
Adds zoom function

### DIFF
--- a/TTS/engine_wrapper.py
+++ b/TTS/engine_wrapper.py
@@ -3,11 +3,8 @@ import re
 from pathlib import Path
 from typing import Tuple
 
-# import sox
-# from mutagen import MutagenError
-# from mutagen.mp3 import MP3, HeaderNotFoundError
 import numpy as np
-import translators as ts
+import translators
 from moviepy.audio.AudioClip import AudioClip
 from moviepy.audio.fx.volumex import volumex
 from moviepy.editor import AudioFileClip
@@ -172,6 +169,6 @@ def process_text(text: str, clean: bool = True):
     new_text = sanitize_text(text) if clean else text
     if lang:
         print_substep("Translating Text...")
-        translated_text = ts.google(text, to_language=lang)
+        translated_text = translators.google(text, to_language=lang)
         new_text = sanitize_text(translated_text)
     return new_text

--- a/utils/.config.template.toml
+++ b/utils/.config.template.toml
@@ -31,6 +31,7 @@ storymodemethod= { optional = true, default = 1, example = 1, explanation = "Sty
 storymode_max_length = { optional = true, default = 1000, example = 1000, explanation = "Max length of the storymode video in characters. 200 characters are approximately 50 seconds.", type = "int", nmin = 1, oob_error = "It's very hard to make a video under a second." }
 resolution_w = { optional = false, default = 1080, example = 1440, explantation = "Sets the width in pixels of the final video" }
 resolution_h = { optional = false, default = 1920, example = 2560, explantation = "Sets the height in pixels of the final video" }
+zoom = { optional = true, default = 1, example = 1.1, explanation = "Sets the browser zoom level. Useful if you want the text larger.", type = "float", nmin = 0.1, nmax = 2, oob_error = "The text is really difficult to read at a zoom level higher than 2" }
 
 [settings.background]
 background_choice = { optional = true, default = "minecraft", example = "rocket-league", options = ["minecraft", "gta", "rocket-league", "motor-gta", "csgo-surf", "cluster-truck", "minecraft-2","multiversus","fall-guys","steep", ""], explanation = "Sets the background for the video based on game name" }

--- a/video_creation/final_video.py
+++ b/video_creation/final_video.py
@@ -1,13 +1,12 @@
 import multiprocessing
 import os
 import re
-import shutil
 from os.path import exists # Needs to be imported specifically
 from typing import Final
 from typing import Tuple, Any
 
 import ffmpeg
-import translators as ts
+import translators
 from PIL import Image
 from rich.console import Console
 from rich.progress import track
@@ -18,11 +17,11 @@ from utils.console import print_step, print_substep
 from utils.thumbnail import create_thumbnail
 from utils.videos import save_data
 
-console = Console()
-
 import tempfile
 import threading
 import time
+
+console = Console()
 
 
 class ProgressFfmpeg(threading.Thread):
@@ -73,7 +72,7 @@ def name_normalize(name: str) -> str:
     lang = settings.config["reddit"]["thread"]["post_lang"]
     if lang:
         print_substep("Translating filename...")
-        translated_name = ts.google(name, to_language=lang)
+        translated_name = translators.google(name, to_language=lang)
         return translated_name
     else:
         return name

--- a/video_creation/screenshot_downloader.py
+++ b/video_creation/screenshot_downloader.py
@@ -158,9 +158,20 @@ def get_screenshots_of_reddit_posts(reddit_object: dict, screenshot_num: int):
 
         postcontentpath = f"assets/temp/{reddit_id}/png/title.png"
         try:
-            page.locator('[data-test-id="post-content"]').screenshot(
-                path=postcontentpath
-            )
+            if(settings.config["settings"]["zoom"] != 1):
+                # store zoom settings
+                zoom = settings.config["settings"]["zoom"]
+                # zoom the body of the page
+                page.evaluate("document.body.style.zoom="+str(zoom))
+                # as zooming the body doesn't change the properties of the divs, we need to adjust for the zoom
+                location = page.locator('[data-test-id="post-content"]').bounding_box()
+                for i in location:
+                    location[i] = float("{:.2f}".format(location[i]*zoom))
+                page.screenshot(clip=location, path=postcontentpath)
+            else:
+                page.locator('[data-test-id="post-content"]').screenshot(
+                    path=postcontentpath
+                )
         except Exception as e:
             print_substep("Something went wrong!", style="red")
             resp = input(
@@ -214,9 +225,20 @@ def get_screenshots_of_reddit_posts(reddit_object: dict, screenshot_num: int):
                         [comment_tl, comment["comment_id"]],
                     )
                 try:
-                    page.locator(f"#t1_{comment['comment_id']}").screenshot(
-                        path=f"assets/temp/{reddit_id}/png/comment_{idx}.png"
-                    )
+                    if(settings.config["settings"]["zoom"] != 1):
+                        # store zoom settings
+                        zoom = settings.config["settings"]["zoom"]
+                        # zoom the body of the page
+                        page.evaluate("document.body.style.zoom="+str(zoom))
+                        # as zooming the body doesn't change the properties of the divs, we need to adjust for the zoom
+                        location = page.locator(f"#t1_{comment['comment_id']}").bounding_box()
+                        for i in location:
+                            location[i] = float("{:.2f}".format(location[i]*zoom))
+                        page.screenshot(clip=location, path=f"assets/temp/{reddit_id}/png/comment_{idx}.png")
+                    else:
+                        page.locator(f"#t1_{comment['comment_id']}").screenshot(
+                            path=f"assets/temp/{reddit_id}/png/comment_{idx}.png"
+                        )
                 except TimeoutError:
                     del reddit_object["comments"]
                     screenshot_num += 1

--- a/video_creation/screenshot_downloader.py
+++ b/video_creation/screenshot_downloader.py
@@ -230,6 +230,8 @@ def get_screenshots_of_reddit_posts(reddit_object: dict, screenshot_num: int):
                         zoom = settings.config["settings"]["zoom"]
                         # zoom the body of the page
                         page.evaluate("document.body.style.zoom="+str(zoom))
+                        # scroll comment into view
+                        page.locator(f"#t1_{comment['comment_id']}").scroll_into_view_if_needed()
                         # as zooming the body doesn't change the properties of the divs, we need to adjust for the zoom
                         location = page.locator(f"#t1_{comment['comment_id']}").bounding_box()
                         for i in location:

--- a/video_creation/screenshot_downloader.py
+++ b/video_creation/screenshot_downloader.py
@@ -3,7 +3,7 @@ import re
 from pathlib import Path
 from typing import Dict, Final
 
-import translators as ts
+import translators
 from playwright.async_api import async_playwright  # pylint: disable=unused-import
 from playwright.sync_api import ViewportSize, sync_playwright
 from rich.progress import track
@@ -144,7 +144,7 @@ def get_screenshots_of_reddit_posts(reddit_object: dict, screenshot_num: int):
 
         if lang:
             print_substep("Translating post...")
-            texts_in_tl = ts.google(
+            texts_in_tl = translators.google(
                 reddit_object["thread_title"],
                 to_language=lang,
             )
@@ -158,7 +158,7 @@ def get_screenshots_of_reddit_posts(reddit_object: dict, screenshot_num: int):
 
         postcontentpath = f"assets/temp/{reddit_id}/png/title.png"
         try:
-            if(settings.config["settings"]["zoom"] != 1):
+            if settings.config["settings"]["zoom"] != 1:
                 # store zoom settings
                 zoom = settings.config["settings"]["zoom"]
                 # zoom the body of the page
@@ -216,7 +216,7 @@ def get_screenshots_of_reddit_posts(reddit_object: dict, screenshot_num: int):
                 # translate code
 
                 if settings.config["reddit"]["thread"]["post_lang"]:
-                    comment_tl = ts.google(
+                    comment_tl = translators.google(
                         comment["comment_body"],
                         to_language=settings.config["reddit"]["thread"]["post_lang"],
                     )
@@ -225,7 +225,7 @@ def get_screenshots_of_reddit_posts(reddit_object: dict, screenshot_num: int):
                         [comment_tl, comment["comment_id"]],
                     )
                 try:
-                    if(settings.config["settings"]["zoom"] != 1):
+                    if settings.config["settings"]["zoom"] != 1:
                         # store zoom settings
                         zoom = settings.config["settings"]["zoom"]
                         # zoom the body of the page


### PR DESCRIPTION
# Description

Adds the ability to zoom in for screenshots. 

I found the text to be a little small in the videos, so I added the option to config a zoom level.

An example showing zoom levels 1 (default), 1.25 and 1.5:
<img width="1022" alt="image" src="https://user-images.githubusercontent.com/69778531/234060867-d07434dd-4a2a-4ad9-ba7f-b0f70f94b54e.png">



# Issue Fixes

<!-- Fixes #(issue) if relevant-->

None

# Checklist:

- [X] I am pushing changes to the **develop** branch
- [X] I am using the recommended development environment
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have formatted and linted my code using python-black and pylint
- [X] I have cleaned up unnecessary files
- [X] My changes generate no new warnings
- [X] My changes follow the existing code-style
- [X] My changes are relevant to the project

# Any other information (e.g how to test the changes)
* Haven't worked on GUI *
Could potentially use some rejigging to make the value make more sense. 
Although the current format aligns with the browser. My initial instinct was to use a value of 2, before realising 200% is really quite overkill:
<img width="800" alt="image" src="https://user-images.githubusercontent.com/69778531/232178733-ba2ce8a0-b008-4cce-98dd-7a9f3efd9cbf.png">