### PR TITLE
Use yt-dlp for downloading the background videos

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ moviepy==1.0.3
 playwright==1.23.0
 praw==7.6.1
 prawcore~=2.3.0
-pytube==12.1.0
 requests==2.28.1
 rich==13.3.1
 toml==0.10.2
@@ -20,3 +19,4 @@ spacy==3.4.1
 torch==1.12.1
 transformers==4.25.1
 ffmpeg-python==0.2.0
+yt-dlp==2023.3.4

--- a/video_creation/background.py
+++ b/video_creation/background.py
@@ -7,10 +7,9 @@ from typing import Any, Tuple
 
 from moviepy.editor import VideoFileClip
 from moviepy.video.io.ffmpeg_tools import ffmpeg_extract_subclip
-from pytube import YouTube
-from pytube.cli import on_progress
 from utils import settings
 from utils.console import print_step, print_substep
+import yt_dlp
 
 # Load background videos
 with open("./utils/backgrounds.json") as json_file:
@@ -72,9 +71,14 @@ def download_background(background_config: Tuple[str, str, str, Any]):
     )
     print_substep("Downloading the backgrounds videos... please be patient 🙏 ")
     print_substep(f"Downloading {filename} from {uri}")
-    YouTube(uri, on_progress_callback=on_progress).streams.filter(
-        res="1080p"
-    ).first().download("assets/backgrounds", filename=f"{credit}-{filename}")
+    ydl_opts = {
+        'format': "bestvideo[height<=1080][ext=mp4]",
+        "outtmpl": f"assets/backgrounds/{credit}-{filename}",
+        "retries": 10,
+    }
+
+    with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+        ydl.download(uri)
     print_substep("Background video downloaded successfully! 🎉", style="bold green")
 
 


### PR DESCRIPTION
# Description

Uses yt-dlp instead of pytube, which is really slow for me

# Issue Fixes

None

# Checklist:

- [x] I am pushing changes to the **develop** branch
- [x] I am using the recommended development environment
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have formatted and linted my code using python-black and pylint
- [x] I have cleaned up unnecessary files
- [x] My changes generate no new warnings
- [x] My changes follow the existing code-style
- [x] My changes are relevant to the project

# Any other information (e.g how to test the changes)

None
