### PR TITLE
Fixed video download error by enabling authentication

### DIFF
--- a/video_creation/background.py
+++ b/video_creation/background.py
@@ -72,7 +72,7 @@ def download_background(background_config: Tuple[str, str, str, Any]):
     )
     print_substep("Downloading the backgrounds videos... please be patient 🙏 ")
     print_substep(f"Downloading {filename} from {uri}")
-    YouTube(uri, on_progress_callback=on_progress).streams.filter(
+    YouTube(uri, use_oauth=True, allow_oauth_cache=True, on_progress_callback=on_progress).streams.filter(
         res="1080p"
     ).first().download("assets/backgrounds", filename=f"{credit}-{filename}")
     print_substep("Background video downloaded successfully! 🎉", style="bold green")


### PR DESCRIPTION
# Description

Changed one simple line of code to enable oauth to fix crashing on background video  download

# Issue Fixes

Fixes issue #1601 


None

# Checklist:

- [ ] I am pushing changes to the **develop** branch
- [ ] I am using the recommended development environment
- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have formatted and linted my code using python-black and pylint
- [ x] I have cleaned up unnecessary files
- [ x] My changes generate no new warnings
- [x ] My changes follow the existing code-style
- [x ] My changes are relevant to the project

# Any other information (e.g how to test the changes)

Added use_oauth=True, allow_oauth_cache=True to the pytube args to enable authentication. When downloading a video, you will be asked to go to https://google.com/device and enter a code. Once you enter that code on the page, you have authenticated the script to use google, and you're good to go!