### PR TITLE
Add periods fix 

### DIFF
--- a/TTS/engine_wrapper.py
+++ b/TTS/engine_wrapper.py
@@ -55,9 +55,20 @@ class TTSEngine:
         self,
     ):  # adds periods to the end of paragraphs (where people often forget to put them) so tts doesn't blend sentences
         for comment in self.reddit_object["comments"]:
+            # remove links
+            regex_urls = r"((http|https)\:\/\/)?[a-zA-Z0-9\.\/\?\:@\-_=#]+\.([a-zA-Z]){2,6}([a-zA-Z0-9\.\&\/\?\:@\-_=#])*"
+            comment["comment_body"] = re.sub(regex_urls, " ", comment["comment_body"])
             comment["comment_body"] = comment["comment_body"].replace("\n", ". ")
+            comment["comment_body"] = re.sub(r'\bAI\b', 'A.I', comment["comment_body"])
+            comment["comment_body"] = re.sub(r'\bAGI\b', 'A.G.I', comment["comment_body"])
             if comment["comment_body"][-1] != ".":
                 comment["comment_body"] += "."
+            comment["comment_body"] = comment["comment_body"].replace(". . .", ".")
+            comment["comment_body"] = comment["comment_body"].replace(".. . ", ".")
+            comment["comment_body"] = comment["comment_body"].replace(". . ", ".")
+            comment["comment_body"] = re.sub(r'\."\.', '".', comment["comment_body"])
+            print(comment["comment_body"])
+
 
     def run(self) -> Tuple[int, int]:
         Path(self.path).mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
# Description

I've been getting a handful of issues related to the TTS engine.
`Code: 1, reason: probably the aid value isn't correct, message: Text-to-speech isn't supported for this language`

I did some digging and found the [add_periods](https://github.com/elebumm/RedditVideoMakerBot/blob/develop/TTS/engine_wrapper.py#L54-L60) method can break the comments on occasion.

At times it can send back any combination of the following:

- .".
- . . . 
- . . 

Leaving TTS to break the comment down and attempt to read " . ", which isn't possible on it's own.

My changes are a bit of a quick fix, and I think this entire method probably needs an overhaul. I've also added the remove links to here, as I occasionally found that caused issues passing to TTS.

# Issue Fixes

Fixes #1591 

This issue pops up a bit in the discord too.

None

# Checklist:

- [x] I am pushing changes to the **develop** branch
- [x] I am using the recommended development environment
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have formatted and linted my code using python-black and pylint
- [x] I have cleaned up unnecessary files
- [x] My changes generate no new warnings
- [x] My changes follow the existing code-style
- [x] My changes are relevant to the project

# Any other information (e.g how to test the changes)

Tricky to test as you need to find just the right post to cause the issues.
You can test it with postid = 13539n6 but it would be good to test on some other posts that break TTS.
