### PR TITLE
Reddit credentials validation in screenshot_downloader.py

### DIFF
--- a/video_creation/screenshot_downloader.py
+++ b/video_creation/screenshot_downloader.py
@@ -115,6 +115,19 @@ def get_screenshots_of_reddit_posts(reddit_object: dict, screenshot_num: int):
         )
         page.locator("button[class$='m-full-width']").click()
         page.wait_for_timeout(5000)
+        
+        login_error_div = page.locator(".AnimatedForm__errorMessage").first
+        if login_error_div.is_visible():
+            login_error_message = login_error_div.inner_text()
+            if login_error_message.strip() == "":
+                # The div element is empty, no error
+                pass
+            else:
+                # The div contains an error message
+                print_substep("Your reddit credentials are incorrect! Please modify them accordingly in the config.toml file.", style="red")
+                exit()
+        else:
+            pass
 
         page.wait_for_load_state()
         # Get the thread screenshot


### PR DESCRIPTION
# Description

If the user enters incorrect Reddit credentials, the playwright locator will time out at line 175 without providing an explanation. As a result, the browser will be unable to log in to Reddit using the wrong credentials, and access to the desired post will be denied. To rectify this issue, a more user-friendly approach is needed.

# Issue Fixes

https://github.com/elebumm/RedditVideoMakerBot/issues/1596

None

# Checklist:

- [✅] I am pushing changes to the **develop** branch
- [✅] I am using the recommended development environment
- [✅] I have performed a self-review of my own code
- [✅] I have commented my code, particularly in hard-to-understand areas
- [✅] I have formatted and linted my code using python-black and pylint
- [✅] I have cleaned up unnecessary files
- [✅] My changes generate no new warnings
- [✅] My changes follow the existing code-style
- [✅] My changes are relevant to the project

# Any other information (e.g how to test the changes)

If you run the program without my changes, you can disable headless mode and enter incorrect Reddit credentials inside of config.toml. You will encounter a timeout exception from playwright without any explanation to the user regarding the cause of the error.

With my modifications, the program performs a check to determine whether the Reddit login is returning an error message. If an error message is received, the user is promptly informed to update their credentials in config.toml. This change makes the program more user-friendly and helps users to identify and resolve issues with their Reddit credentials.