### PR TITLE
Replace acronyms with full words

### DIFF
--- a/TTS/engine_wrapper.py
+++ b/TTS/engine_wrapper.py
@@ -81,7 +81,6 @@ class TTSEngine:
             for acronym in acronyms_json:
                 if re.search(acronym, self.reddit_object["thread_title"]):
                     self.reddit_object["thread_title"] = self.reddit_object["thread_title"].replace(acronym, acronyms_json[acronym])
-                print(self.reddit_object["thread_title"])
 
                 for idx, post in enumerate(self.reddit_object["thread_post"]):
                     if re.search(acronym, post):

--- a/TTS/engine_wrapper.py
+++ b/TTS/engine_wrapper.py
@@ -76,19 +76,16 @@ class TTSEngine:
         with open("./utils/acronyms.json") as json_file:
 
             acronyms_json = json.load(json_file)
-            # for acronym in acronyms_json:
-            #     print(acronym, ":", acronyms_json[acronym])
+            
+            # Repalcing each acronym in acronyms_json for the whole post & comments
             for acronym in acronyms_json:
-                print(type(self.reddit_object["thread_title"]))
                 if re.search(acronym, self.reddit_object["thread_title"]):
                     self.reddit_object["thread_title"] = self.reddit_object["thread_title"].replace(acronym, acronyms_json[acronym])
                 print(self.reddit_object["thread_title"])
 
-                print(type(self.reddit_object["thread_post"]))
                 for idx, post in enumerate(self.reddit_object["thread_post"]):
                     if re.search(acronym, post):
                         self.reddit_object["thread_post"][idx] = self.reddit_object["thread_post"][idx].replace(acronym, acronyms_json[acronym])
-                #print(self.reddit_object["thread_post"])
 
                 for comment in self.reddit_object["comments"]:
                     if re.search(acronym, comment["comment_body"]):

--- a/TTS/engine_wrapper.py
+++ b/TTS/engine_wrapper.py
@@ -2,6 +2,7 @@ import os
 import re
 from pathlib import Path
 from typing import Tuple
+import json
 
 # import sox
 # from mutagen import MutagenError
@@ -69,12 +70,39 @@ class TTSEngine:
             comment["comment_body"] = re.sub(r'\."\.', '".', comment["comment_body"])
             print(comment["comment_body"])
 
+    def replace_acronyms(
+            self,
+    ):
+        with open("./utils/acronyms.json") as json_file:
+
+            acronyms_json = json.load(json_file)
+            # for acronym in acronyms_json:
+            #     print(acronym, ":", acronyms_json[acronym])
+            for acronym in acronyms_json:
+                print(type(self.reddit_object["thread_title"]))
+                if re.search(acronym, self.reddit_object["thread_title"]):
+                    self.reddit_object["thread_title"] = self.reddit_object["thread_title"].replace(acronym, acronyms_json[acronym])
+                print(self.reddit_object["thread_title"])
+
+                print(type(self.reddit_object["thread_post"]))
+                for idx, post in enumerate(self.reddit_object["thread_post"]):
+                    if re.search(acronym, post):
+                        self.reddit_object["thread_post"][idx] = self.reddit_object["thread_post"][idx].replace(acronym, acronyms_json[acronym])
+                #print(self.reddit_object["thread_post"])
+
+                for comment in self.reddit_object["comments"]:
+                    if re.search(acronym, comment["comment_body"]):
+                        comment["comment_body"] = comment["comment_body"].replace(acronym, acronyms_json[acronym])
 
     def run(self) -> Tuple[int, int]:
         Path(self.path).mkdir(parents=True, exist_ok=True)
         print_step("Saving Text to MP3 files...")
 
         self.add_periods()
+
+        if settings.config["settings"]["tts"]["replace_acronyms"]:
+            self.replace_acronyms()
+
         self.call_tts("title", process_text(self.reddit_object["thread_title"]))
         # processed_text = ##self.reddit_object["thread_post"] != ""
         idx = None

--- a/utils/.config.template.toml
+++ b/utils/.config.template.toml
@@ -31,6 +31,7 @@ storymodemethod= { optional = true, default = 1, example = 1, explanation = "Sty
 storymode_max_length = { optional = true, default = 1000, example = 1000, explanation = "Max length of the storymode video in characters. 200 characters are approximately 50 seconds.", type = "int", nmin = 1, oob_error = "It's very hard to make a video under a second." }
 resolution_w = { optional = false, default = 1080, example = 1440, explantation = "Sets the width in pixels of the final video" }
 resolution_h = { optional = false, default = 1920, example = 2560, explantation = "Sets the height in pixels of the final video" }
+replace_acronyms = { optional = true, default = false, example = "True", explantation = "TTS will read acronyms as full words. Add acronyms to utils/acronyms.json as needed." }
 
 [settings.background]
 background_video = { optional = true, default = "minecraft", example = "rocket-league", options = ["minecraft", "gta", "rocket-league", "motor-gta", "csgo-surf", "cluster-truck", "minecraft-2","multiversus","fall-guys","steep", ""], explanation = "Sets the background for the video based on game name" }

--- a/utils/acronyms.json
+++ b/utils/acronyms.json
@@ -1,0 +1,11 @@
+{
+    "__comment": "You can add more acronyms here as needed.",
+    "AITA": "Am I The Asshole",
+    "AITAH": "Am I The Asshole",
+    "NTA": "Not The Asshole",
+    "YTA": "Yes The Asshole",
+    "DEA": "Does Anyone Else",
+    "iirc": "If I Remember Correctly",
+    "imo": "In My Opinion",
+    "fyi": "For your information"
+}


### PR DESCRIPTION
# Description

As suggested in issue #1254, added a setting to replace all ancronyms in a thread (including title, post and comments) with full words.

> For example: AITA -> Am I The Asshole

- Added `utils\acronyms.json` It's very minimal, but users are free to add their own (and its stated when configuring the setting)
- Added `replace_ancronyms` setting, default is set to False. Setting to true will replace all the acronyms with full words.
- Changed the `engine_wrapper.py` to replace the ancronyms if the setting is set to True, right after adding periods

# Issue Fixes

Not an issue but a feature

# Checklist:

- [X] I am pushing changes to the **develop** branch
- [X] I am using the recommended development environment
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have formatted and linted my code using python-black and pylint
- [X] I have cleaned up unnecessary files
- [X] My changes generate no new warnings
- [X] My changes follow the existing code-style
- [X] My changes are relevant to the project

# Any other information (e.g how to test the changes)

None

> Note: This is my first PR so hopefully i didn't mess something up 


.