### PR TITLE
Reddit redesign

### DIFF
--- a/utils/playwright.py
+++ b/utils/playwright.py
@@ -1,0 +1,7 @@
+def clear_cookie_by_name(context, cookie_cleared_name):
+    cookies = context.cookies()
+    filtered_cookies = [
+        cookie for cookie in cookies if cookie["name"] != cookie_cleared_name
+    ]
+    context.clear_cookies()
+    context.add_cookies(filtered_cookies)

--- a/video_creation/screenshot_downloader.py
+++ b/video_creation/screenshot_downloader.py
@@ -11,6 +11,7 @@ from rich.progress import track
 from utils import settings
 from utils.console import print_step, print_substep
 from utils.imagenarator import imagemaker
+from utils.playwright import clear_cookie_by_name
 
 from utils.videos import save_data
 
@@ -117,6 +118,13 @@ def get_screenshots_of_reddit_posts(reddit_object: dict, screenshot_num: int):
         page.wait_for_timeout(5000)
 
         page.wait_for_load_state()
+        # Handle the redesign
+        # Check if the redesign optout cookie is set
+        if page.locator("#redesign-beta-optin-btn").is_visible():
+            # Clear the redesign optout cookie
+            clear_cookie_by_name(context, "redesign_optout")
+            # Reload the page for the redesign to take effect
+            page.reload()
         # Get the thread screenshot
         page.goto(reddit_object["thread_url"], timeout=0)
         page.set_viewport_size(ViewportSize(width=W, height=H))


### PR DESCRIPTION
# Description

This PR adds a clear_cookies_by_name function, that is then used to clear the 'redesign_optout' cookie if a user has opted out of the redesign.

# Issue Fixes

#1647

# Checklist:

- [x] I am pushing changes to the **develop** branch
- [x] I am using the recommended development environment
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have formatted and linted my code using python-black and pylint
- [x] I have cleaned up unnecessary files
- [x] My changes generate no new warnings
- [x] My changes follow the existing code-style
- [x] My changes are relevant to the project

# Any other information (e.g how to test the changes)

## To Test

1. Opt out of the Reddit redesign in https://www.reddit.com/settings/
2. Run the tool, you should see the tool runs fine
3. Check Reddit in a new browser to confirm you're still seeing the old Reddit


## Justification for this solution

I've seen the issue appear a handful of times where the screenshot tool stops working because a user is on the old reddit design.

While we could handle this by throwing an error, asking the user to change to the new design, I believe this is a better way to handle the issue.

With this solution, we're not asking users to change their preferences. We should allow users to use reddit as they like outside of this tool and thus I opted for the clearing of the cookie instead.

This solution has no impact on the users preferences outside of the headless browser.

While it does potentially add unwanted code to the tool, again, I don't think we should be deciding how a user decides to use reddit.
