### PR TITLE
fixes title query

### DIFF
--- a/video_creation/screenshot_downloader.py
+++ b/video_creation/screenshot_downloader.py
@@ -150,7 +150,7 @@ def get_screenshots_of_reddit_posts(reddit_object: dict, screenshot_num: int):
             )
 
             page.evaluate(
-                "tl_content => document.querySelector('[data-test-id=\"post-content\"] > div:nth-child(3) > div > div').textContent = tl_content",
+                "tl_content => document.querySelector('[data-adclicklocation=\"title\"] > div > div > h1').textContent = tl_content",
                 texts_in_tl,
             )
         else:


### PR DESCRIPTION
# Description

While investigating another translator issue, I came across an issue when a post has no content.

Compare the following 2 threads:

1. https://www.reddit.com/r/netflix/comments/13pw7uf/netflixs_update_on_sharing_starting_today_we_will/
![image](https://github.com/elebumm/RedditVideoMakerBot/assets/69778531/ea0a52c0-41e3-4eae-97bc-c3167fd62d54)

2. https://www.reddit.com/r/netflix/comments/13pzycz/just_received_the_password_sharing_email_what_now/
![image](https://github.com/elebumm/RedditVideoMakerBot/assets/69778531/1c48b86f-5cde-4d3a-8bf1-a672bfbbd033)

The title of the post lives at different depths in the DOM. 

This PR should allow for any of the options, as it instead targets: `data-adclicklocation="title"` which remains constant.

# Issue Fixes

#1599

# Checklist:

- [X] I am pushing changes to the **develop** branch
- [X] I am using the recommended development environment
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have formatted and linted my code using python-black and pylint
- [X] I have cleaned up unnecessary files
- [X] My changes generate no new warnings
- [X] My changes follow the existing code-style
- [X] My changes are relevant to the project

# Any other information (e.g how to test the changes)

I haven't tested it for every post type so there may be some unexpected results.

I also advise we take a look at how we've done all our document queries, as there may be some more places we can implement a cleaner query. 
