### PR TITLE
Fix adding ffmpeg to path

### DIFF
--- a/utils/ffmpeg_install.py
+++ b/utils/ffmpeg_install.py
@@ -23,7 +23,7 @@ def ffmpeg_install_windows():
             os.remove(f"ffmpeg/doc/{file}")
         os.rmdir("ffmpeg/doc")
         # Add to the path
-        subprocess.run("setx /M PATH \"%PATH%;%CD%\\ffmpeg\"", shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        subprocess.run("setx PATH \"%PATH%;%CD%\\ffmpeg\"", shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         print("FFmpeg installed successfully! Please restart your computer and then re-run the program.")
         exit()
     except Exception as e:


### PR DESCRIPTION
# Description

This fixes adding ffmpeg to the path by adding it to the user path instead of the system path, which doesn't require admin privileges to do

# Issue Fixes

#1653 and duplicates

# Checklist:

- [x] I am pushing changes to the **develop** branch
- [x] I am using the recommended development environment
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have formatted and linted my code using python-black and pylint
- [x] I have cleaned up unnecessary files
- [x] My changes generate no new warnings
- [x] My changes follow the existing code-style
- [x] My changes are relevant to the project

# Any other information (e.g how to test the changes)

None
