### PR TITLE
Add ability to create multiple shorts and create a long form video

### DIFF
--- a/generate_long_video.py
+++ b/generate_long_video.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+from utils import settings
+import sys
+
+num_of_vids_to_be_conc = input("How many videos would you like to be concatenated into a single video? ")
+try:
+    num_of_vids_to_be_conc = int(num_of_vids_to_be_conc)
+except:
+    print("Input could not be converted to integer, please enter a number!")
+    sys.exit(400)
+
+remove_past_results = input("Would you like to remove past results? (y/n) ")
+
+if remove_past_results not in ["y", "n"]: print("Please enter a valid option (y/n)!"); sys.exit(400)
+else:
+    if remove_past_results == "y": remove_past_results = True
+    if remove_past_results == "n": remove_past_results = False
+
+abs_directory = Path().absolute()
+config = settings.check_toml(f"{abs_directory}/utils/.config.template.toml", f"{abs_directory}/config.toml")
+
+config["settings"]["resolution_w"] = 1920
+config["settings"]["resolution_h"] = 1080
+
+from video_generator import VideoGenerator
+
+video_gen = VideoGenerator(config)
+video_gen.generate_long_video(num_of_vids_to_be_conc, remove_past_results)

--- a/generate_shorts.py
+++ b/generate_shorts.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+from utils import settings
+import sys
+
+num_of_shorts = input("How many shorts would you like to be generated? ")
+try:
+    num_of_shorts = int(num_of_shorts)
+except:
+    print("Input could not be converted to integer, please enter a number!")
+    sys.exit(400)
+    
+remove_past_results = input("Would you like to remove past results? (y/n) ")
+
+if remove_past_results not in ["y", "n"]: print("Please enter a valid option (y/n)!"); sys.exit(400)
+else:
+    if remove_past_results == "y": remove_past_results = True
+    if remove_past_results == "n": remove_past_results = False
+
+
+abs_directory = Path().absolute()
+config = settings.check_toml(f"{abs_directory}/utils/.config.template.toml", f"{abs_directory}/config.toml")
+
+config["settings"]["resolution_w"] = 1080
+config["settings"]["resolution_h"] = 1920
+
+from video_generator import VideoGenerator
+
+video_gen = VideoGenerator(config)
+video_gen.generate_shorts(num_of_shorts, remove_past_results)

--- a/video_generator.py
+++ b/video_generator.py
@@ -1,0 +1,57 @@
+import os, shutil
+from moviepy.editor import concatenate_videoclips, VideoFileClip
+from main import run
+
+# This class must be run from the top level, not from inside the containing directory
+
+class VideoGenerator():
+    def __init__(self, config):
+        self.config = config
+    
+    def _concatenate_videos(self, video_paths, output_path):
+        video_clips = []
+        
+        for path in video_paths:
+            video_clip = VideoFileClip(path)
+            video_clips.append(video_clip)
+            
+        final_clip = concatenate_videoclips(video_clips)
+        final_clip.write_videofile(output_path, codec="libx264", fps=24)
+    
+    def generate_shorts(self, num_of_shorts, remove_past_results=True):
+        if remove_past_results:
+            if os.path.exists("results"):
+                shutil.rmtree("results")
+
+        for _ in range(num_of_shorts):
+            print("="*50)
+            run(self.config)
+        
+        print(f"Videos have been made!")
+    
+    def generate_long_video(self, num_of_videos_to_be_conc, remove_past_results=True):
+        if remove_past_results:
+            if os.path.exists("results"):
+                shutil.rmtree("results")
+            
+            if os.path.exists("long_form_videos_results"):
+                shutil.rmtree("long_form_videos_results")
+
+        for _ in range(num_of_videos_to_be_conc):
+            print("="*50)
+            run(self.config)
+        
+        print("Concatinating videos...")
+        videos = []
+        subreddit = self.config["reddit"]["thread"]["subreddit"]
+        videos_folder = f"results/{subreddit}"
+        for video in os.listdir(videos_folder):
+            videos.append(os.path.join(videos_folder, video))
+        
+        if not os.path.exists("long_form_videos_results"):
+            os.mkdir("long_form_videos_results")
+
+        output_filename = f"long_form_videos_results{videos[0].split('/')[-1].split('.')[0]} + other threads from {subreddit}!.mp4"
+        self._concatenate_videos(videos, output_filename)
+
+        print("Done!")


### PR DESCRIPTION
# Description

I have added three total files.

1. video_generator.py: It holds functions to create multiple shorts in one go and also contains a function to create a long form video by concatenating shorts
2. generate_shorts.py: Runs the function inside of the video_generator to generate multiple shorts as it requires some options
3. generate_long_video.py: Runs the function inside of the video_generator to generate a long form video

# Issue Fixes

<!-- Fixes #(issue) if relevant-->

None

# Checklist:

- [x] I am pushing changes to the **develop** branch
- [x] I am using the recommended development environment
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have formatted and linted my code using python-black and pylint
- [x] I have cleaned up unnecessary files
- [x] My changes generate no new warnings
- [ ] My changes follow the existing code-style
- [x] My changes are relevant to the project

# Any other information (e.g how to test the changes)

* To generate multiple shorts you can simply run the generate_shorts.py and it will ask for how many shorts you would like to generate. If you want to generate a long video you can run the generate_long_video.py and it will ask you how many shorts (with the correct resolution) would you like to concatenate into a single long form video.

* Another thing to mention is that when you are running these files the output will be quite unclear as to what step it is currently on.
