### PR TITLE
Fix translators

### DIFF
--- a/TTS/engine_wrapper.py
+++ b/TTS/engine_wrapper.py
@@ -186,6 +186,6 @@ def process_text(text: str, clean: bool = True):
     new_text = sanitize_text(text) if clean else text
     if lang:
         print_substep("Translating Text...")
-        translated_text = translators.google(text, to_language=lang)
+        translated_text = translators.translate_text(text, translator="google", to_language=lang)
         new_text = sanitize_text(translated_text)
     return new_text

--- a/video_creation/final_video.py
+++ b/video_creation/final_video.py
@@ -72,7 +72,7 @@ def name_normalize(name: str) -> str:
     lang = settings.config["reddit"]["thread"]["post_lang"]
     if lang:
         print_substep("Translating filename...")
-        translated_name = translators.google(name, to_language=lang)
+        translated_name = translators.translate_text(name, translator="google", to_language=lang)
         return translated_name
     else:
         return name

--- a/video_creation/screenshot_downloader.py
+++ b/video_creation/screenshot_downloader.py
@@ -168,9 +168,10 @@ def get_screenshots_of_reddit_posts(reddit_object: dict, screenshot_num: int):
 
         if lang:
             print_substep("Translating post...")
-            texts_in_tl = translators.google(
+            texts_in_tl = translators.translate_text(
                 reddit_object["thread_title"],
                 to_language=lang,
+                translator="google",
             )
 
             page.evaluate(
@@ -240,8 +241,9 @@ def get_screenshots_of_reddit_posts(reddit_object: dict, screenshot_num: int):
                     # translate code
 
                 if settings.config["reddit"]["thread"]["post_lang"]:
-                    comment_tl = translators.google(
+                    comment_tl = translators.translate_text(
                         comment["comment_body"],
+                        translator="google",
                         to_language=settings.config["reddit"]["thread"]["post_lang"],
                     )
                     page.evaluate(


### PR DESCRIPTION
# Description
Fix translators package. The old version used a version that is no longer supported and no longer works, this being “translators.google()”

# Issue Fixes
- Fixed translation error (Changed `translators.google(…)` to `translators.translate_text(translator=“google”, …`

# Checklist:

- [x] I am pushing changes to the **develop** branch
- [x] I am using the recommended development environment
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have formatted and linted my code using python-black and pylint
- [x] I have cleaned up unnecessary files
- [x] My changes generate no new warnings
- [x] My changes follow the existing code-style
- [x] My changes are relevant to the project

# Any other information (e.g how to test the changes)

None
