### PR TITLE
Confirm out_time_ms is a number

### DIFF
--- a/video_creation/final_video.py
+++ b/video_creation/final_video.py
@@ -46,8 +46,12 @@ class ProgressFfmpeg(threading.Thread):
         if lines:
             for line in lines:
                 if "out_time_ms" in line:
-                    out_time_ms = line.split("=")[1]
-                    return int(out_time_ms) / 1000000.0
+                    out_time_ms_str = line.split("=")[1].strip()
+                    if out_time_ms_str.isnumeric():
+                        return float(out_time_ms_str) / 1000000.0
+                    else:
+                        # Handle the case when "N/A" is encountered
+                        return None
         return None
 
     def stop(self):


### PR DESCRIPTION
# Description

In get_latest_ms_progress(), the value of out_time_ms can equal 'N/A\n', this code will prevent a ValueError when dividing a string by a number. Since this is only a progress indicator, it should not crash the program.

# Issue Fixes

Prevents a ValueError when dividing a string by a number

# Checklist:

- [x] I am pushing changes to the **develop** branch
- [x] I am using the recommended development environment
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have formatted and linted my code using python-black and pylint
- [x] I have cleaned up unnecessary files
- [x] My changes generate no new warnings
- [x] My changes follow the existing code-style
- [x] My changes are relevant to the project

# Any other information (e.g how to test the changes)

None
