### PR TITLE
Fix: Conversion Failed! Error message and 403

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,4 +20,4 @@ torch==2.0.1
 transformers==4.29.2
 ffmpeg-python==0.2.0
 elevenlabs==0.2.17
-yt-dlp==2023.3.4
+yt-dlp==2023.7.6


### PR DESCRIPTION
Issue
Error: "Error: ERROR: [download] Got error: HTTP Error 403: Forbidden "
Error: "Conversion failed! while creating final video"

Root Cause
Both are caused by 403 errors occurring in outdated yt-dlp package

# Description
Update yt-dlp version in requirements.txt.
I'm making this change as I see in the discord many new people encountering these errors on a daily basis.

# Issue Fixes

Fixes #1797
Fixes #1785

None

# Checklist:

- [x] I am pushing changes to the **develop** branch
- [x] I am using the recommended development environment
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have formatted and linted my code using python-black and pylint
- [x] I have cleaned up unnecessary files
- [x] My changes generate no new warnings
- [x] My changes follow the existing code-style
- [x] My changes are relevant to the project

# Any other information (e.g how to test the changes)

None
