### PR TITLE
#1817 bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Please read our [contributing guidelines](CONTRIBUTING.md) for more detailed inf
 
 Elebumm (Lewis#6305) - https://github.com/elebumm (Founder)
 
-Jason (JasonLovesDoggo#1904) - https://github.com/JasonLovesDoggo (Maintainer)
+Jason (personality.json) - https://github.com/JasonLovesDoggo (Maintainer)
 
 Simon (OpenSourceSimon) - https://github.com/OpenSourceSimon
 

--- a/utils/cleanup.py
+++ b/utils/cleanup.py
@@ -14,7 +14,13 @@ def cleanup(reddit_id) -> int:
         int: How many files were deleted
     """
     directory = f"assets/temp/{reddit_id}/"
+    deleted_files_count = 0
+
     if exists(directory):
+        # Count the number of files before deleting
+        for root, dirs, files in os.walk(directory):
+            deleted_files_count += len(files)
+
         shutil.rmtree(directory)
 
-        return 1
+        return deleted_files_count

--- a/utils/cleanup.py
+++ b/utils/cleanup.py
@@ -13,7 +13,7 @@ def cleanup(reddit_id) -> int:
     Returns:
         int: How many files were deleted
     """
-    directory = f"../assets/temp/{reddit_id}/"
+    directory = f"assets/temp/{reddit_id}/"
     if exists(directory):
         shutil.rmtree(directory)
 

--- a/video_creation/final_video.py
+++ b/video_creation/final_video.py
@@ -1,6 +1,7 @@
 import multiprocessing
 import os
 import re
+import shutil
 import tempfile
 import threading
 import time
@@ -436,9 +437,11 @@ def make_final_video(
 
         old_percentage = pbar.n
         pbar.update(100 - old_percentage)
+
     pbar.close()
     save_data(subreddit, filename + ".mp4", title, idx, background_config["video"][2])
+
     print_step("Removing temporary files 🗑")
-    cleanups = cleanup(reddit_id)
-    print_substep(f"Removed {cleanups} temporary files 🗑")
+    cleanup(reddit_id)
     print_step("Done! 🎉 The video is in the results folder 📁")
+    time.sleep(1)  # Prevents the last 2 print_step functions from not showing up

--- a/video_creation/final_video.py
+++ b/video_creation/final_video.py
@@ -1,7 +1,6 @@
 import multiprocessing
 import os
 import re
-import shutil
 import tempfile
 import threading
 import time

--- a/video_creation/final_video.py
+++ b/video_creation/final_video.py
@@ -441,6 +441,7 @@ def make_final_video(
     save_data(subreddit, filename + ".mp4", title, idx, background_config["video"][2])
 
     print_step("Removing temporary files 🗑")
-    cleanup(reddit_id)
+    cleanups = cleanup(reddit_id)
+    print_substep(f"Removed {cleanups} temporary files 🗑")
     print_step("Done! 🎉 The video is in the results folder 📁")
     time.sleep(1)  # Prevents the last 2 print_step functions from not showing up


### PR DESCRIPTION
# Description

Fixed the function used for cleaning up the root/assets/temp directory after successful generation or after forceful stoppage of generation. Additionally fixed 2 last print statements not showing up because of code exiting too quickly.

# Issue Fixes

closes #1817

# Checklist:

- [X] I am pushing changes to the **develop** branch
- [X] I am using the recommended development environment
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have formatted and linted my code using python-black and pylint
- [X] I have cleaned up unnecessary files
- [X] My changes generate no new warnings
- [X] My changes follow the existing code-style
- [X] My changes are relevant to the project

# Any other information (e.g how to test the changes)

Before this PR, you can see the temp folder in root/assets/temp is being cluttered by all the temporary files that are being generated and used to create the final output. After this PR, if the output is successfully generated or some temporary files are created and the generation is stopped mid way, the temporary files are cleaned up.
