### PR TITLE
#1865 Bug fix

### DIFF
--- a/TTS/engine_wrapper.py
+++ b/TTS/engine_wrapper.py
@@ -127,6 +127,10 @@ class TTSEngine:
                 continue
             else:
                 self.call_tts(f"{idx}-{idy}.part", newtext)
+                if (
+                    self.length > self.max_length
+                ):  # This prevents the video from being longer than self.max_length seconds.
+                    return
                 with open(f"{self.path}/list.txt", "w") as f:
                     for idz in range(0, len(split_text)):
                         f.write("file " + f"'{idx}-{idz}.part.mp3'" + "\n")


### PR DESCRIPTION
# Description

Added a check to the `split_post` function to check the video length, such that the generated video is not longer than the maximum length.

# Issue Fixes

Fixes issue https://github.com/elebumm/RedditVideoMakerBot/issues/1865 .

# Checklist:

- [X] I am pushing changes to the **develop** branch
- [X] I am using the recommended development environment
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have formatted and linted my code using python-black and pylint
- [X] I have cleaned up unnecessary files
- [X] My changes generate no new warnings
- [X] My changes follow the existing code-style
- [X] My changes are relevant to the project

# Any other information (e.g how to test the changes)

Run the script and now the generated video should not be longer than the maximum length.