### PR TITLE
Fixing Streamlabspolly issue

### DIFF
--- a/TTS/streamlabs_polly.py
+++ b/TTS/streamlabs_polly.py
@@ -43,8 +43,9 @@ class StreamlabsPolly:
                     f"Please set the config variable STREAMLABS_POLLY_VOICE to a valid voice. options are: {voices}"
                 )
             voice = str(settings.config["settings"]["tts"]["streamlabs_polly_voice"]).capitalize()
+        headers = {"referer": "https://streamlabs.com"}
         body = {"voice": voice, "text": text, "service": "polly"}
-        response = requests.post(self.url, data=body)
+        response = requests.post(self.url, headers=headers, data=body)
         if not check_ratelimit(response):
             self.run(text, filepath, random_voice)
 


### PR DESCRIPTION
# Description

This pull request fixes an issue that was occuring with streamlabspolly. The TTS service now requires an additional `referer` header set to `https://streamlabs.com`.

# Issue Fixes

Fixes #1942 

# Checklist:

- [x] I am pushing changes to the **develop** branch
- [x] I am using the recommended development environment
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have formatted and linted my code using python-black and pylint
- [x] I have cleaned up unnecessary files
- [x] My changes generate no new warnings
- [x] My changes follow the existing code-style
- [x] My changes are relevant to the project

# Any other information (e.g how to test the changes)

None