### PR TITLE
bug(#1974): verify GitHub API response before trying to access the JSON dictionary

### DIFF
--- a/utils/version.py
+++ b/utils/version.py
@@ -7,6 +7,11 @@ def checkversion(__VERSION__: str):
     response = requests.get(
         "https://api.github.com/repos/elebumm/RedditVideoMakerBot/releases/latest"
     )
+    if response.status_code == 403:  # Rate limit
+        print(
+            f"Skipping script version check because we exceeded GitHub's rate limit. Using version ({__VERSION__})."
+        )
+        return
     latestversion = response.json()["tag_name"]
     if __VERSION__ == latestversion:
         print_step(f"You are using the newest version ({__VERSION__}) of the bot")


### PR DESCRIPTION
# Description

I've added a check for response code 403 from the GitHub API to avoid being rate-limited.
If we're rate-limited in the current code, the script exits.
With this implementation, it just throws a warning.

# Issue Fixes

Fixes #1974 

None

# Checklist:

- [x] I am pushing changes to the **develop** branch
- [x] I am using the recommended development environment
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have formatted and linted my code using python-black and pylint
- [x] I have cleaned up unnecessary files
- [x] My changes generate no new warnings
- [x] My changes follow the existing code-style
- [x] My changes are relevant to the project

# Any other information (e.g how to test the changes)

None
