### PR TITLE
Unhide spoiler content

### DIFF
--- a/TTS/GTTS.py
+++ b/TTS/GTTS.py
@@ -10,7 +10,7 @@ class GTTS:
         self.max_chars = 5000
         self.voices = []
 
-    def run(self, text, filepath):
+    def run(self, text, filepath, random_voice: bool = False):
         tts = gTTS(
             text=text,
             lang=settings.config["reddit"]["thread"]["post_lang"] or "en",

--- a/utils/playwright.py
+++ b/utils/playwright.py
@@ -3,3 +3,10 @@ def clear_cookie_by_name(context, cookie_cleared_name):
     filtered_cookies = [cookie for cookie in cookies if cookie["name"] != cookie_cleared_name]
     context.clear_cookies()
     context.add_cookies(filtered_cookies)
+
+def unhide_spoiler_content(page):
+    spoiler_containers = page.locator("shreddit-blurred-container[reason='spoiler']")
+    for i in range(spoiler_containers.count()):
+        container = spoiler_containers.nth(i)
+        if container.is_visible():
+            container.locator("text=View spoiler").click()


### PR DESCRIPTION
# Description

This function reveals spoiler content on the current page.

# Issue Fixes

If a screenshot needs to include both text and spoiler content, the spoiler content will now be visible.

# Checklist:

- [ ] I am pushing changes to the **develop** branch
- [Y] I am using the recommended development environment
- [Y] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have formatted and linted my code using python-black and pylint
- [ ] I have cleaned up unnecessary files
- [ ] My changes generate no new warnings
- [Y] My changes follow the existing code-style
- [Y] My changes are relevant to the project

# Any other information (e.g how to test the changes)

None
