### PR TITLE
feat: add Docker GUI support with VNC and noVNC

### DIFF
--- a/Dockerfile.gui
+++ b/Dockerfile.gui
@@ -1,0 +1,35 @@
+FROM python:3.10.14-slim
+
+# Install system dependencies including browser support and VNC
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ffmpeg \
+    xvfb \
+    x11vnc \
+    novnc \
+    websockify \
+    fluxbox \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set display for headless browser
+ENV DISPLAY=:99
+ENV VNC_PORT=5900
+ENV NOVNC_PORT=6080
+
+RUN mkdir /app
+ADD . /app
+WORKDIR /app
+
+# Install Python dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Install Playwright browsers with system dependencies
+RUN playwright install --with-deps chromium
+
+# Copy the entrypoint script
+COPY docker-gui-entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+EXPOSE 5900 6080
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["python3", "main.py"]

--- a/docker-compose.gui.yml
+++ b/docker-compose.gui.yml
@@ -1,0 +1,15 @@
+version: "3.8"
+
+services:
+  reddit-bot-gui:
+    build:
+      context: .
+      dockerfile: Dockerfile.gui
+    ports:
+      - "5900:5900"   # VNC
+      - "6080:6080"   # noVNC (web browser access)
+    volumes:
+      - ./results:/app/results
+      - ./.config.toml:/app/.config.toml
+    environment:
+      - DISPLAY=:99

--- a/docker-gui-entrypoint.sh
+++ b/docker-gui-entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+# Start virtual framebuffer
+Xvfb :99 -screen 0 1920x1080x24 &
+sleep 1
+
+# Start lightweight window manager
+fluxbox &
+
+# Start VNC server (no password by default, use -rfbauth for security)
+x11vnc -display :99 -forever -nopw -rfbport ${VNC_PORT:-5900} &
+
+# Start noVNC web client (accessible via browser at http://localhost:6080)
+websockify --web /usr/share/novnc/ ${NOVNC_PORT:-6080} localhost:${VNC_PORT:-5900} &
+
+echo "============================================"
+echo " GUI is available at:"
+echo "   VNC:   vnc://localhost:${VNC_PORT:-5900}"
+echo "   Web:   http://localhost:${NOVNC_PORT:-6080}/vnc.html"
+echo "============================================"
+
+# Run the main command
+exec "$@"


### PR DESCRIPTION
## Summary
- Added `Dockerfile.gui` with Xvfb, VNC (x11vnc), and noVNC for running the bot with a visible browser inside Docker
- Added `docker-gui-entrypoint.sh` that starts virtual display, window manager, VNC server, and noVNC web client
- Added `docker-compose.gui.yml` for easy startup with port mappings
- Playwright chromium installed with system dependencies

### Usage
```bash
# Build and run with GUI
docker compose -f docker-compose.gui.yml up --build

# Access the GUI
# VNC client: vnc://localhost:5900
# Web browser: http://localhost:6080/vnc.html
```

The existing headless `Dockerfile` is preserved unchanged.

Fixes #2321