### PR TITLE
fix(gui): use background_videos metadata file

### DIFF
--- a/GUI.py
+++ b/GUI.py
@@ -91,10 +91,10 @@ def videos_json():
     return send_from_directory("video_creation/data", "videos.json")
 
 
-# Make backgrounds.json accessible
+# Make background_videos.json accessible via the existing backgrounds.json endpoint
 @app.route("/backgrounds.json")
 def backgrounds_json():
-    return send_from_directory("utils", "backgrounds.json")
+    return send_from_directory("utils", "background_videos.json")
 
 
 # Make videos in results folder accessible

--- a/utils/gui_utils.py
+++ b/utils/gui_utils.py
@@ -127,12 +127,12 @@ def modify_settings(data: dict, config_load, checks: dict):
 
 # Delete background video
 def delete_background(key):
-    # Read backgrounds.json
-    with open("utils/backgrounds.json", "r", encoding="utf-8") as backgrounds:
+    # Read background_videos.json
+    with open("utils/background_videos.json", "r", encoding="utf-8") as backgrounds:
         data = json.load(backgrounds)
 
-    # Remove background from backgrounds.json
-    with open("utils/backgrounds.json", "w", encoding="utf-8") as backgrounds:
+    # Remove background from background_videos.json
+    with open("utils/background_videos.json", "w", encoding="utf-8") as backgrounds:
         if data.pop(key, None):
             json.dump(data, backgrounds, ensure_ascii=False, indent=4)
         else:
@@ -181,7 +181,7 @@ def add_background(youtube_uri, filename, citation, position):
     filename = filename.replace(" ", "_")
 
     # Check if the background doesn't already exist
-    with open("utils/backgrounds.json", "r", encoding="utf-8") as backgrounds:
+    with open("utils/background_videos.json", "r", encoding="utf-8") as backgrounds:
         data = json.load(backgrounds)
 
         # Check if key isn't already taken
@@ -195,7 +195,7 @@ def add_background(youtube_uri, filename, citation, position):
             return
 
     # Add background video to json file
-    with open("utils/backgrounds.json", "r+", encoding="utf-8") as backgrounds:
+    with open("utils/background_videos.json", "r+", encoding="utf-8") as backgrounds:
         data = json.load(backgrounds)
 
         data[filename] = [youtube_uri, filename + ".mp4", citation, position]


### PR DESCRIPTION
## Summary
- fix the GUI background metadata route to read from the shipped `background_videos.json`
- align the add/delete background helpers with the actual background metadata filename
- restore GUI background metadata operations on current master
